### PR TITLE
chore(gitignore): organize global gitignore with categorized patterns

### DIFF
--- a/.gitignore_global
+++ b/.gitignore_global
@@ -1,3 +1,33 @@
+# === macOS ===
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+.Spotlight-V100
+.Trashes
+
+# === Editor: Vim ===
+*.swp
+*.swo
+*~
+.netrwhist
+Session.vim
+
+# === Editor: JetBrains IDEs ===
 .idea/
+
+# === Editor: VSCode ===
+.vscode/
+
+# === direnv ===
 .envrc
-.claude/settings.local.json
+
+# === Claude Code ===
+# 基本すべて除外し、プロジェクト側の .gitignore で共有すべきものを ! で許可する
+.claude/*
+!.claude/settings.json
+!.claude/CLAUDE.md
+!.claude/skills/
+!.claude/hooks/
+!.claude/commands/
+!.claude/agents/

--- a/.gitignore_global
+++ b/.gitignore_global
@@ -25,6 +25,7 @@ Session.vim
 # === Claude Code ===
 # 基本すべて除外し、プロジェクト側の .gitignore で共有すべきものを ! で許可する
 .claude/*
+.claude/.*
 !.claude/settings.json
 !.claude/CLAUDE.md
 !.claude/skills/


### PR DESCRIPTION
## Summary
global gitignore をカテゴリ別に整理し、不足していたパターンを追加。

## Changes
- **macOS**: `.DS_Store`, `.AppleDouble`, `.LSOverride`, `._*`, `.Spotlight-V100`, `.Trashes`
- **Vim**: `*.swp`, `*.swo`, `*~`, `.netrwhist`, `Session.vim`
- **JetBrains IDEs**: `.idea/`（既存）
- **VSCode**: `.vscode/`
- **direnv**: `.envrc`（既存）
- **Claude Code**: `.claude/*` で基本除外し、共有すべきもの（`settings.json`, `CLAUDE.md`, `skills/`, `hooks/`, `commands/`, `agents/`）を `!` で許可する方式に変更

## Files Changed
- Modified: `.gitignore_global`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated global git ignore configuration to optimize handling of project settings files while preserving essential configuration files for development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->