### PR TITLE
feat(skills): add measure-context skill for token usage measurement

### DIFF
--- a/.claude/skills/measure-context.md
+++ b/.claude/skills/measure-context.md
@@ -1,0 +1,95 @@
+---
+name: measure-context
+description: "初期コンテキストのトークン消費量を計測する。CLAUDE.md最適化の前後比較に使用。任意のリポジトリで利用可能。"
+user-invocable: true
+allowed-tools: Bash, Read, Glob, Grep
+disable-model-invocation: true
+---
+
+初期コンテキストのトークン消費量を計測し、レポートを表示する。
+
+## Step 1: 自動読み込みファイルのサイズ計測
+
+以下のファイルが存在する場合、行数・バイト数を取得する：
+
+- `./CLAUDE.md`（プロジェクト）
+- `./.claude/rules/` 配下の全 `.md` ファイル
+- `~/.claude/CLAUDE.md`（グローバル）
+- プロジェクト固有の memory ディレクトリ（`~/.claude/projects/` 配下の対応ディレクトリ）
+
+プロジェクト固有の memory パスは以下のコマンドで動的に特定する：
+
+```bash
+# カレントディレクトリのパスからプロジェクト固有ディレクトリを導出
+PROJECT_HASH=$(pwd | sed 's|/|-|g; s|^-||')
+MEMORY_DIR="$HOME/.claude/projects/${PROJECT_HASH}/memory"
+if [ -d "$MEMORY_DIR" ]; then
+  echo "Memory directory: $MEMORY_DIR"
+  wc -lc "$MEMORY_DIR"/*.md 2>/dev/null || echo "No memory files"
+fi
+```
+
+## Step 2: claude CLI でトークン実測
+
+Bash で以下を実行し、JSON 出力から usage を抽出する：
+
+```bash
+echo "hello" | claude -p --output-format json 2>/dev/null | python3 -c "
+import sys, json
+data = json.loads(sys.stdin.read())
+for item in data:
+    if item.get('type') == 'result':
+        u = item.get('usage', {})
+        mu = item.get('modelUsage', {})
+        print(json.dumps({
+            'total': {
+                'input_tokens': u.get('input_tokens'),
+                'cache_creation': u.get('cache_creation_input_tokens'),
+                'cache_read': u.get('cache_read_input_tokens'),
+                'output_tokens': u.get('output_tokens'),
+                'cost_usd': item.get('total_cost_usd')
+            },
+            'models': {k: {
+                'input': v.get('inputTokens'),
+                'cacheCreation': v.get('cacheCreationInputTokens'),
+                'cacheRead': v.get('cacheReadInputTokens'),
+                'output': v.get('outputTokens'),
+                'costUSD': v.get('costUSD')
+            } for k, v in mu.items()}
+        }, indent=2, ensure_ascii=False))
+        break
+"
+```
+
+## Step 3: レポート表示
+
+以下のフォーマットで結果を表示する：
+
+```
+## コンテキスト計測レポート
+
+### ファイルサイズ
+| ファイル | 行数 | バイト |
+|---|---|---|
+| Project CLAUDE.md | X | X |
+| Global CLAUDE.md | X | X |
+| Rules (*.md) | X | X |
+| Memory (*.md) | X | X |
+| 合計 | X | X |
+
+### トークン実測
+| 項目 | トークン数 |
+|---|---|
+| input_tokens | X |
+| cache_creation | X |
+| cache_read | X |
+| 初期コンテキスト合計 | X |
+| コスト | $X.XX |
+```
+
+引数に `--compare` が指定された場合:
+1. 現在の計測結果を表示
+2. `git stash` で変更を退避
+3. 同じ計測を実行
+4. `git stash pop` で復元
+5. 改善前後の比較テーブルを表示


### PR DESCRIPTION
## Summary

初期コンテキストのトークン消費量を計測するスキル `/measure-context` を追加。CLAUDE.md 最適化の前後比較に使用でき、任意のリポジトリで利用可能。

## Changes

- **measure-context.md**: 新規スキル追加
  - 自動読み込みファイル（CLAUDE.md、rules、memory）のサイズ計測
  - `claude -p` による実トークン数の計測
  - レポート表示（ファイルサイズ + トークン実測）
  - `--compare` オプションで改善前後の比較をサポート

## Commits

- `88dcc33` feat(skills): add measure-context skill for token usage measurement

## Files Changed

- Added: 1 file
  - `.claude/skills/measure-context.md` (+95)

## Testing

- [ ] `/measure-context` スキルの実行確認
- [ ] `--compare` オプションの動作確認

## Architecture & Flow Diagram

```mermaid
graph LR
    A[/measure-context] --> B[Step 1: ファイルサイズ計測]
    B --> C[CLAUDE.md / Rules / Memory]
    A --> D[Step 2: トークン実測]
    D --> E[claude -p --output-format json]
    C --> F[Step 3: レポート表示]
    E --> F
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context measurement capability to analyze initial context size (lines and bytes) across configuration files.
  * Introduced token usage reporting functionality to display input, cache creation, cache read, output, and cost metrics.
  * Added comparison feature (`--compare` flag) to measure context before and after changes with side-by-side reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->