### PR TITLE
feat(statusline): improve performance, info density, and adaptive width

### DIFF
--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -1,6 +1,24 @@
 #!/bin/bash
 input=$(cat)
 
+# Guards
+[ -z "$input" ] && echo "" && exit 0
+command -v jq >/dev/null 2>&1 || { echo "[no jq]"; exit 0; }
+
+# Single jq call to extract all values
+IFS=$'\t' read -r MODEL CONTEXT_SIZE CURRENT_TOKENS FIVE_HOUR SEVEN_DAY <<< "$(
+  echo "$input" | jq -r '[
+    .model.display_name,
+    (.context_window.context_window_size // 0),
+    ((.context_window.current_usage // {}) | ((.input_tokens // 0) + (.cache_creation_input_tokens // 0) + (.cache_read_input_tokens // 0))),
+    (.rate_limits.five_hour.used_percentage // ""),
+    (.rate_limits.seven_day.used_percentage // "")
+  ] | @tsv'
+)"
+
+RESET='\033[0m'
+DIM='\033[2m'
+
 # ANSI color by percentage: green(0%) -> yellow(50%) -> red(100%)
 color_by_pct() {
     local pct=$1
@@ -14,9 +32,6 @@ color_by_pct() {
     fi
     printf '\033[38;2;%d;%d;0m' "$r" "$g"
 }
-
-RESET='\033[0m'
-DIM='\033[2m'
 
 # Bar gauge using block characters (8 steps per char, 5 chars = 40 steps)
 bar_gauge() {
@@ -38,39 +53,72 @@ bar_gauge() {
     echo -n "$bar"
 }
 
-# Format a metric with color and bar
-fmt_metric() {
+# Format token count as human-readable (e.g., 450k, 1.2M)
+format_tokens() {
+    local t=$1
+    if [ "$t" -ge 1000000 ]; then
+        local major=$((t / 1000000))
+        local minor=$(((t % 1000000) / 100000))
+        if [ "$minor" -gt 0 ]; then
+            printf '%d.%dM' "$major" "$minor"
+        else
+            printf '%dM' "$major"
+        fi
+    elif [ "$t" -ge 1000 ]; then
+        printf '%dk' $((t / 1000))
+    else
+        printf '%d' "$t"
+    fi
+}
+
+# Format rate limit metric with color and bar
+fmt_rate() {
     local label=$1 pct=$2
     local c
     c=$(color_by_pct "$pct")
     printf '%b%s%b %b%s%b %b%3d%%%b' "$DIM" "$label" "$RESET" "$c" "$(bar_gauge "$pct")" "$RESET" "$c" "$pct" "$RESET"
 }
 
-# Model name
-MODEL=$(echo "$input" | jq -r '.model.display_name')
-
 # Context window usage
-CONTEXT_SIZE=$(echo "$input" | jq -r '.context_window.context_window_size')
-USAGE=$(echo "$input" | jq '.context_window.current_usage')
 CTX_PCT=0
-if [ "$USAGE" != "null" ] && [ "$CONTEXT_SIZE" != "null" ] && [ "$CONTEXT_SIZE" != "0" ]; then
-    CURRENT_TOKENS=$(echo "$USAGE" | jq '(.input_tokens // 0) + (.cache_creation_input_tokens // 0) + (.cache_read_input_tokens // 0)')
+if [ "$CURRENT_TOKENS" != "null" ] && [ "$CONTEXT_SIZE" != "null" ] && [ "$CONTEXT_SIZE" != "0" ]; then
     CTX_PCT=$((CURRENT_TOKENS * 100 / CONTEXT_SIZE))
 fi
+# Clamp to 0-100
+[ "$CTX_PCT" -gt 100 ] && CTX_PCT=100
+[ "$CTX_PCT" -lt 0 ] && CTX_PCT=0
 
-# Rate limits
-FIVE_HOUR=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
-SEVEN_DAY=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+# Format context metric with token counts
+CTX_COLOR=$(color_by_pct "$CTX_PCT")
+CTX_OUTPUT=$(printf '%bctx%b %b%s%b %b%s/%s%b' \
+    "$DIM" "$RESET" \
+    "$CTX_COLOR" "$(bar_gauge "$CTX_PCT")" "$RESET" \
+    "$CTX_COLOR" "$(format_tokens "$CURRENT_TOKENS")" "$(format_tokens "$CONTEXT_SIZE")" "$RESET")
 
 # Build output
-OUTPUT="$(fmt_metric "ctx" "$CTX_PCT")"
-[ -n "$FIVE_HOUR" ] && OUTPUT+="  $(fmt_metric "5h" "${FIVE_HOUR%.*}")"
-[ -n "$SEVEN_DAY" ] && OUTPUT+="  $(fmt_metric "7d" "${SEVEN_DAY%.*}")"
+OUTPUT="$CTX_OUTPUT"
 
-# Git branch
+# Rate limits (only show when >= 20%)
+if [ -n "$FIVE_HOUR" ]; then
+    FIVE_INT=${FIVE_HOUR%.*}
+    [ "$FIVE_INT" -gt 100 ] 2>/dev/null && FIVE_INT=100
+    [ "${FIVE_INT:-0}" -ge 20 ] && OUTPUT+="  $(fmt_rate "5h" "$FIVE_INT")"
+fi
+if [ -n "$SEVEN_DAY" ]; then
+    SEVEN_INT=${SEVEN_DAY%.*}
+    [ "$SEVEN_INT" -gt 100 ] 2>/dev/null && SEVEN_INT=100
+    [ "${SEVEN_INT:-0}" -ge 20 ] && OUTPUT+="  $(fmt_rate "7d" "$SEVEN_INT")"
+fi
+
+# Git branch with dirty indicator
 if git rev-parse --git-dir > /dev/null 2>&1; then
     BRANCH=$(git branch --show-current 2>/dev/null)
-    [ -n "$BRANCH" ] && OUTPUT+="  ${DIM}${BRANCH}${RESET}"
+    if [ -n "$BRANCH" ]; then
+        DIRTY=""
+        git diff --quiet HEAD 2>/dev/null || DIRTY="*"
+        git diff --cached --quiet HEAD 2>/dev/null || DIRTY+="+"
+        OUTPUT+="  ${DIM}${BRANCH}${DIRTY}${RESET}"
+    fi
 fi
 
 echo -e "[$MODEL] $OUTPUT"

--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -6,13 +6,15 @@ input=$(cat)
 command -v jq >/dev/null 2>&1 || { echo "[no jq]"; exit 0; }
 
 # Single jq call to extract all values
-IFS=$'\t' read -r MODEL CONTEXT_SIZE CURRENT_TOKENS FIVE_HOUR SEVEN_DAY <<< "$(
+IFS=$'\t' read -r MODEL CONTEXT_SIZE CURRENT_TOKENS FIVE_HOUR FIVE_RESET SEVEN_DAY SEVEN_RESET <<< "$(
   echo "$input" | jq -r '[
     .model.display_name,
     (.context_window.context_window_size // 0),
     ((.context_window.current_usage // {}) | ((.input_tokens // 0) + (.cache_creation_input_tokens // 0) + (.cache_read_input_tokens // 0))),
     (.rate_limits.five_hour.used_percentage // ""),
-    (.rate_limits.seven_day.used_percentage // "")
+    (.rate_limits.five_hour.resets_at // ""),
+    (.rate_limits.seven_day.used_percentage // ""),
+    (.rate_limits.seven_day.resets_at // "")
   ] | @tsv'
 )"
 
@@ -71,12 +73,38 @@ format_tokens() {
     fi
 }
 
-# Format rate limit metric with color and bar
+# Format remaining time until reset (e.g., "2h13m", "3d5h")
+format_remaining() {
+    local resets_at=$1
+    [ -z "$resets_at" ] && return
+    local now remaining
+    now=$(date +%s)
+    remaining=$((resets_at - now))
+    [ "$remaining" -le 0 ] && return
+    local days=$((remaining / 86400))
+    local hours=$(((remaining % 86400) / 3600))
+    local mins=$(((remaining % 3600) / 60))
+    if [ "$days" -gt 0 ]; then
+        printf '%dd%dh' "$days" "$hours"
+    elif [ "$hours" -gt 0 ]; then
+        printf '%dh%02dm' "$hours" "$mins"
+    else
+        printf '%dm' "$mins"
+    fi
+}
+
+# Format rate limit metric with color, bar, and reset countdown
 fmt_rate() {
-    local label=$1 pct=$2
+    local label=$1 pct=$2 resets_at=$3
     local c
     c=$(color_by_pct "$pct")
-    printf '%b%s%b %b%s%b %b%3d%%%b' "$DIM" "$label" "$RESET" "$c" "$(bar_gauge "$pct")" "$RESET" "$c" "$pct" "$RESET"
+    local reset_str
+    reset_str=$(format_remaining "$resets_at")
+    if [ -n "$reset_str" ]; then
+        printf '%b%s%b %b%s%b %b%3d%%%b %b⟳%s%b' "$DIM" "$label" "$RESET" "$c" "$(bar_gauge "$pct")" "$RESET" "$c" "$pct" "$RESET" "$DIM" "$reset_str" "$RESET"
+    else
+        printf '%b%s%b %b%s%b %b%3d%%%b' "$DIM" "$label" "$RESET" "$c" "$(bar_gauge "$pct")" "$RESET" "$c" "$pct" "$RESET"
+    fi
 }
 
 # Context window usage
@@ -102,12 +130,12 @@ OUTPUT="$CTX_OUTPUT"
 if [ -n "$FIVE_HOUR" ]; then
     FIVE_INT=${FIVE_HOUR%.*}
     [ "$FIVE_INT" -gt 100 ] 2>/dev/null && FIVE_INT=100
-    [ "${FIVE_INT:-0}" -ge 20 ] && OUTPUT+="  $(fmt_rate "5h" "$FIVE_INT")"
+    [ "${FIVE_INT:-0}" -ge 20 ] && OUTPUT+="  $(fmt_rate "5h" "$FIVE_INT" "$FIVE_RESET")"
 fi
 if [ -n "$SEVEN_DAY" ]; then
     SEVEN_INT=${SEVEN_DAY%.*}
     [ "$SEVEN_INT" -gt 100 ] 2>/dev/null && SEVEN_INT=100
-    [ "${SEVEN_INT:-0}" -ge 20 ] && OUTPUT+="  $(fmt_rate "7d" "$SEVEN_INT")"
+    [ "${SEVEN_INT:-0}" -ge 20 ] && OUTPUT+="  $(fmt_rate "7d" "$SEVEN_INT" "$SEVEN_RESET")"
 fi
 
 # Git branch with dirty indicator

--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -160,7 +160,7 @@ if git rev-parse --git-dir > /dev/null 2>&1; then
     BRANCH=$(git branch --show-current 2>/dev/null)
     if [ -n "$BRANCH" ]; then
         DIRTY=""
-        git diff --quiet HEAD 2>/dev/null || DIRTY="*"
+        git diff --quiet 2>/dev/null || DIRTY="*"
         git diff --cached --quiet HEAD 2>/dev/null || DIRTY+="+"
         PARTS+=("$(printf '%b%s%b' "$DIM" "${BRANCH}${DIRTY}" "$RESET")")
     fi

--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -109,7 +109,8 @@ fmt_rate() {
 
 # Strip ANSI escape sequences to measure visible width
 visible_len() {
-    printf '%s' "$1" | sed 's/\x1b\[[0-9;]*m//g' | wc -m | tr -d ' '
+    local esc=$(printf '\033')
+    printf '%s' "$1" | sed "s/${esc}\[[0-9;]*m//g" | wc -m | tr -d ' '
 }
 
 # Terminal width

--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -180,4 +180,4 @@ while [ "$(visible_len "$OUTPUT")" -gt "$COLS" ] && [ "${#PARTS[@]}" -gt 1 ]; do
     done
 done
 
-echo -e "$OUTPUT"
+printf '%s\n' "$OUTPUT"

--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -107,6 +107,14 @@ fmt_rate() {
     fi
 }
 
+# Strip ANSI escape sequences to measure visible width
+visible_len() {
+    printf '%s' "$1" | sed 's/\x1b\[[0-9;]*m//g' | wc -m | tr -d ' '
+}
+
+# Terminal width
+COLS=$(tput cols 2>/dev/null || echo 120)
+
 # Context window usage
 CTX_PCT=0
 if [ "$CURRENT_TOKENS" != "null" ] && [ "$CONTEXT_SIZE" != "null" ] && [ "$CONTEXT_SIZE" != "0" ]; then
@@ -116,37 +124,59 @@ fi
 [ "$CTX_PCT" -gt 100 ] && CTX_PCT=100
 [ "$CTX_PCT" -lt 0 ] && CTX_PCT=0
 
-# Format context metric with token counts
+# Build parts array: each element is an ANSI-formatted string
+# Priority order (rightmost gets dropped first):
+#   1. [Model] ctx bar tokens  (always shown)
+#   2. 5h rate limit
+#   3. 7d rate limit
+#   4. git branch
+PARTS=()
+
+# Part 0: model + context (always shown)
 CTX_COLOR=$(color_by_pct "$CTX_PCT")
-CTX_OUTPUT=$(printf '%bctx%b %b%s%b %b%s/%s%b' \
+PARTS+=("$(printf '[%s] %bctx%b %b%s%b %b%s/%s%b' \
+    "$MODEL" \
     "$DIM" "$RESET" \
     "$CTX_COLOR" "$(bar_gauge "$CTX_PCT")" "$RESET" \
-    "$CTX_COLOR" "$(format_tokens "$CURRENT_TOKENS")" "$(format_tokens "$CONTEXT_SIZE")" "$RESET")
+    "$CTX_COLOR" "$(format_tokens "$CURRENT_TOKENS")" "$(format_tokens "$CONTEXT_SIZE")" "$RESET")")
 
-# Build output
-OUTPUT="$CTX_OUTPUT"
-
-# Rate limits (only show when >= 20%)
+# Part 1: 5h rate limit (only when >= 20%)
 if [ -n "$FIVE_HOUR" ]; then
     FIVE_INT=${FIVE_HOUR%.*}
     [ "$FIVE_INT" -gt 100 ] 2>/dev/null && FIVE_INT=100
-    [ "${FIVE_INT:-0}" -ge 20 ] && OUTPUT+="  $(fmt_rate "5h" "$FIVE_INT" "$FIVE_RESET")"
+    [ "${FIVE_INT:-0}" -ge 20 ] && PARTS+=("$(fmt_rate "5h" "$FIVE_INT" "$FIVE_RESET")")
 fi
+
+# Part 2: 7d rate limit (only when >= 20%)
 if [ -n "$SEVEN_DAY" ]; then
     SEVEN_INT=${SEVEN_DAY%.*}
     [ "$SEVEN_INT" -gt 100 ] 2>/dev/null && SEVEN_INT=100
-    [ "${SEVEN_INT:-0}" -ge 20 ] && OUTPUT+="  $(fmt_rate "7d" "$SEVEN_INT" "$SEVEN_RESET")"
+    [ "${SEVEN_INT:-0}" -ge 20 ] && PARTS+=("$(fmt_rate "7d" "$SEVEN_INT" "$SEVEN_RESET")")
 fi
 
-# Git branch with dirty indicator
+# Part 3: git branch
 if git rev-parse --git-dir > /dev/null 2>&1; then
     BRANCH=$(git branch --show-current 2>/dev/null)
     if [ -n "$BRANCH" ]; then
         DIRTY=""
         git diff --quiet HEAD 2>/dev/null || DIRTY="*"
         git diff --cached --quiet HEAD 2>/dev/null || DIRTY+="+"
-        OUTPUT+="  ${DIM}${BRANCH}${DIRTY}${RESET}"
+        PARTS+=("$(printf '%b%s%b' "$DIM" "${BRANCH}${DIRTY}" "$RESET")")
     fi
 fi
 
-echo -e "[$MODEL] $OUTPUT"
+# Assemble: join with "  ", drop rightmost parts until it fits
+OUTPUT="${PARTS[0]}"
+for ((i = 1; i < ${#PARTS[@]}; i++)); do
+    OUTPUT+="  ${PARTS[$i]}"
+done
+
+while [ "$(visible_len "$OUTPUT")" -gt "$COLS" ] && [ "${#PARTS[@]}" -gt 1 ]; do
+    unset 'PARTS[${#PARTS[@]}-1]'
+    OUTPUT="${PARTS[0]}"
+    for ((i = 1; i < ${#PARTS[@]}; i++)); do
+        OUTPUT+="  ${PARTS[$i]}"
+    done
+done
+
+echo -e "$OUTPUT"


### PR DESCRIPTION
## Summary

statusline.sh を全面改善。パフォーマンス最適化、情報密度の向上、端末幅への適応を実装。

## Changes

- **feat(statusline): improve performance, readability, and robustness**
  - jq 呼び出しを6回→1回に統合（~30-60ms 高速化）
  - コンテキスト表示を `45%` → `450k/1M` 形式に変更（残りトークンが一目でわかる）
  - レート制限を20%未満の場合は非表示にしてスペース節約
  - Git dirty indicator（`*` 未ステージ / `+` ステージ済み）を追加
  - エッジケースガード（空入力、jq 未インストール、パーセンテージクランプ）

- **feat(statusline): show rate limit reset countdown**
  - `resets_at` フィールドからリセットまでの残り時間を表示（例: `⟳2h03m`, `⟳3d0h`）

- **feat(statusline): adapt output to terminal width**
  - 端末幅に応じて右側から段階的に省略（ブランチ → 7d → 5h）
  - 改行を防止しつつ重要な情報を優先表示

## Commits

- `6a4509c` feat(statusline): improve performance, readability, and robustness
- `fe0875c` feat(statusline): show rate limit reset countdown
- `30c9253` feat(statusline): adapt output to terminal width

## Files Changed

- Modified: 1 file
  - `.claude/statusline.sh` (+129 -23)

## Testing

- [ ] 各種端末幅（120/80/50/30 cols）での表示確認
- [ ] レート制限 20%未満で非表示になることを確認
- [ ] リセットカウントダウン表示の確認
- [ ] 空入力でクラッシュしないことを確認
- [ ] Claude Code 上での実際の動作確認

## Architecture & Flow Diagram

```mermaid
graph TD
    A[stdin JSON] --> B[Single jq call]
    B --> C[Parts Array]
    C --> D0["[Model] ctx bar tokens"]
    C --> D1["5h bar % ⟳reset"]
    C --> D2["7d bar % ⟳reset"]
    C --> D3["branch*+"]
    D0 & D1 & D2 & D3 --> E{Width check}
    E -->|fits| F[echo full output]
    E -->|overflow| G[Drop rightmost part]
    G --> E
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added input validation to handle missing dependencies gracefully.
  * Improved terminal width detection for proper status display across all screen sizes.

* **Chores**
  * Optimized performance by consolidating data extraction operations.
  * Enhanced formatting of rate limit countdowns and token count displays in the status line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->