### PR TITLE
feat(skills): add sentry-cli skill with reference docs

### DIFF
--- a/.claude/skills/sentry-cli/SKILL.md
+++ b/.claude/skills/sentry-cli/SKILL.md
@@ -1,0 +1,464 @@
+---
+name: sentry-cli
+version: 0.25.0
+description: Guide for using the Sentry CLI to interact with Sentry from the command line. Use when the user asks about viewing issues, events, projects, organizations, making API calls, or authenticating with Sentry via CLI.
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Sentry CLI Usage Guide
+
+Help users interact with Sentry from the command line using the `sentry` CLI.
+
+## Agent Guidance
+
+Best practices and operational guidance for AI coding agents using the Sentry CLI.
+
+### Key Principles
+
+- **Just run the command** — the CLI handles authentication and org/project detection automatically. Don't pre-authenticate or look up org/project before running commands. If auth is needed, the CLI prompts interactively.
+- **Prefer CLI commands over raw API calls** — the CLI has dedicated commands for most tasks. Reach for `sentry issue view`, `sentry issue list`, `sentry trace view`, etc. before constructing API calls manually or fetching external documentation.
+- **Use `sentry schema` to explore the API** — if you need to discover API endpoints, run `sentry schema` to browse interactively or `sentry schema <resource>` to search. This is faster than fetching OpenAPI specs externally.
+- **Use `sentry issue view <id>` to investigate issues** — when asked about a specific issue (e.g., `CLI-G5`, `PROJECT-123`), use `sentry issue view` directly.
+- **Use `--json` for machine-readable output** — pipe through `jq` for filtering. Human-readable output includes formatting that is hard to parse.
+- **The CLI auto-detects org/project** — most commands work without explicit targets by scanning for DSNs in `.env` files, source code, config defaults, and directory names. Only specify `<org>/<project>` when the CLI reports it can't detect the target or detects the wrong one.
+
+### Design Principles
+
+The `sentry` CLI follows conventions from well-known tools — if you're familiar with them, that knowledge transfers directly:
+
+- **`gh` (GitHub CLI) conventions**: The `sentry` CLI uses the same `<noun> <verb>` command pattern (e.g., `sentry issue list`, `sentry org view`). Flags follow `gh` conventions: `--json` for machine-readable output, `--fields` to select specific fields, `-w`/`--web` to open in browser, `-q`/`--query` for filtering, `-n`/`--limit` for result count.
+- **`sentry api` mimics `curl`**: The `sentry api` command provides direct API access with a `curl`-like interface — `--method` for HTTP method, `--data` for request body, `--header` for custom headers. It handles authentication automatically. If you know how to call a REST API with `curl`, the same patterns apply.
+
+### Context Window Tips
+
+- Use `--json --fields` to select specific fields and reduce output size. Run `<command> --help` to see available fields. Example: `sentry issue list --json --fields shortId,title,priority,level,status`
+- Use `--json` when piping output between commands or processing programmatically
+- Use `--limit` to cap the number of results (default is usually 10–100)
+- Prefer `sentry issue view PROJECT-123` over listing and filtering manually
+- Use `sentry api` for endpoints not covered by dedicated commands
+
+### Safety Rules
+
+- Always confirm with the user before running destructive commands: `project delete`, `trial start`
+- For mutations, verify the org/project context looks correct in the command output before proceeding with further changes
+- Never store or log authentication tokens — the CLI manages credentials automatically
+- If the CLI reports the wrong org/project, override with explicit `<org>/<project>` arguments
+
+### Workflow Patterns
+
+#### Investigate an Issue
+
+```bash
+# 1. Find the issue (auto-detects org/project from DSN or config)
+sentry issue list --query "is:unresolved" --limit 5
+
+# 2. Get details
+sentry issue view PROJECT-123
+
+# 3. Get AI root cause analysis
+sentry issue explain PROJECT-123
+
+# 4. Get a fix plan
+sentry issue plan PROJECT-123
+```
+
+#### Explore Traces and Performance
+
+```bash
+# 1. List recent traces (auto-detects org/project)
+sentry trace list --limit 5
+
+# 2. View a specific trace with span tree
+sentry trace view abc123def456...
+
+# 3. View spans for a trace
+sentry span list abc123def456...
+
+# 4. View logs associated with a trace
+sentry trace logs abc123def456...
+```
+
+#### Stream Logs
+
+```bash
+# Stream logs in real-time (auto-detects org/project)
+sentry log list --follow
+
+# Filter logs by severity
+sentry log list --query "severity:error"
+```
+
+#### Explore the API Schema
+
+```bash
+# Browse all API resource categories
+sentry schema
+
+# Search for endpoints related to a resource
+sentry schema issues
+
+# Get details about a specific endpoint
+sentry schema "GET /api/0/organizations/{organization_id_or_slug}/issues/"
+```
+
+#### Manage Releases
+
+```bash
+# Create a release — version must match Sentry.init({ release }) exactly
+sentry release create my-org/1.0.0 --project my-project
+
+# Associate commits via repository integration (needs local git checkout)
+sentry release set-commits my-org/1.0.0 --auto
+
+# Or read commits from local git history (no integration needed)
+sentry release set-commits my-org/1.0.0 --local
+
+# Mark the release as finalized
+sentry release finalize my-org/1.0.0
+
+# Record a production deploy
+sentry release deploy my-org/1.0.0 production
+```
+
+**Key details:**
+- The positional is `<org-slug>/<version>`. In `sentry release create sentry/1.0.0`, `sentry` is the org and `1.0.0` is the version — the slash separates org from version, it is not part of the version string.
+- The **version** must match the `release` value in `Sentry.init()`. If your SDK uses `"1.0.0"`, the command must use `org/1.0.0`.
+- `--auto` requires a Sentry repository integration (GitHub/GitLab/Bitbucket) **and** a local git checkout. It matches your `origin` remote against Sentry's repo list. Without a checkout, use `--local`.
+- With no flag, `set-commits` tries `--auto` first and falls back to `--local` on failure.
+
+#### Arbitrary API Access
+
+```bash
+# GET request (default)
+sentry api /api/0/organizations/my-org/
+
+# POST request with data
+sentry api /api/0/organizations/my-org/projects/ --method POST --data '{"name":"new-project","platform":"python"}'
+```
+
+### Dashboard Layout
+
+Sentry dashboards use a **6-column grid**. When adding widgets, aim to fill complete rows (widths should sum to 6).
+
+Display types with default sizes:
+
+| Display Type | Width | Height | Category | Notes |
+|---|---|---|---|---|
+| `big_number` | 2 | 1 | common | Compact KPI — place 3 per row (2+2+2=6) |
+| `line` | 3 | 2 | common | Half-width chart — place 2 per row (3+3=6) |
+| `area` | 3 | 2 | common | Half-width chart — place 2 per row |
+| `bar` | 3 | 2 | common | Half-width chart — place 2 per row |
+| `table` | 6 | 2 | common | Full-width — always takes its own row |
+| `stacked_area` | 3 | 2 | specialized | Stacked area chart |
+| `top_n` | 3 | 2 | specialized | Top N ranked list |
+| `categorical_bar` | 3 | 2 | specialized | Categorical bar chart |
+| `text` | 3 | 2 | specialized | Static text/markdown widget |
+| `details` | 3 | 2 | internal | Detail view |
+| `wheel` | 3 | 2 | internal | Pie/wheel chart |
+| `rage_and_dead_clicks` | 3 | 2 | internal | Rage/dead click visualization |
+| `server_tree` | 3 | 2 | internal | Hierarchical tree display |
+| `agents_traces_table` | 3 | 2 | internal | Agents traces table |
+
+Use **common** types for general dashboards. Use **specialized** only when specifically requested. Avoid **internal** types unless the user explicitly asks.
+
+Available datasets: `spans` (default), `tracemetrics`, `discover`, `issue`, `error-events`, `logs`. Run `sentry dashboard widget --help` for dataset descriptions, query formats, and examples.
+
+**Row-filling examples:**
+
+```bash
+# 3 KPIs filling one row (2+2+2 = 6)
+sentry dashboard widget add <dashboard> "Error Count" --display big_number --query count
+sentry dashboard widget add <dashboard> "P95 Duration" --display big_number --query p95:span.duration
+sentry dashboard widget add <dashboard> "Throughput" --display big_number --query epm
+
+# 2 charts filling one row (3+3 = 6)
+sentry dashboard widget add <dashboard> "Errors Over Time" --display line --query count
+sentry dashboard widget add <dashboard> "Latency Over Time" --display line --query p95:span.duration
+
+# Full-width table (6 = 6)
+sentry dashboard widget add <dashboard> "Top Endpoints" --display table \
+  --query count --query p95:span.duration \
+  --group-by transaction --sort -count --limit 10
+```
+
+### Quick Reference
+
+#### Time filtering
+
+Use `--period` (alias: `-t`) to filter by time window:
+
+```bash
+sentry trace list --period 1h
+sentry span list --period 24h
+sentry span list -t 7d
+```
+
+#### Scoping to an org or project
+
+Org and project are positional arguments following `gh` CLI conventions:
+
+```bash
+sentry trace list my-org/my-project
+sentry issue list my-org/my-project
+sentry span list my-org/my-project/abc123def456...
+```
+
+#### Listing spans in a trace
+
+Pass the trace ID as a positional argument to `span list`:
+
+```bash
+sentry span list abc123def456...
+sentry span list my-org/my-project/abc123def456...
+```
+
+#### Dataset names for the Events API
+
+When querying the Events API (directly or via `sentry api`), valid dataset values are: `spans`, `transactions`, `logs`, `errors`, `discover`.
+
+### Common Mistakes
+
+- **Wrong issue ID format**: Use `PROJECT-123` (short ID), not the numeric ID `123456789`. The short ID includes the project prefix.
+- **Pre-authenticating unnecessarily**: Don't run `sentry auth login` before every command. The CLI detects missing/expired auth and prompts automatically. Only run `sentry auth login` if you need to switch accounts.
+- **Missing `--json` for piping**: Human-readable output includes formatting. Use `--json` when parsing output programmatically.
+- **Specifying org/project when not needed**: Auto-detection resolves org/project from DSNs, env vars, config defaults, and directory names. Let it work first — only add `<org>/<project>` if the CLI says it can't detect the target or detects the wrong one.
+- **Confusing `--query` syntax**: The `--query` flag uses Sentry search syntax (e.g., `is:unresolved`, `assigned:me`), not free text search.
+- **Not using `--web`**: View commands support `-w`/`--web` to open the resource in the browser — useful for sharing links.
+- **Fetching API schemas instead of using the CLI**: Prefer `sentry schema` to browse the API and `sentry api` to make requests — the CLI handles authentication and endpoint resolution, so there's rarely a need to download OpenAPI specs separately.
+- **Release version mismatch**: The `org/version` positional is `<org-slug>/<version>`, where `org/` is the org, not part of the version. `sentry release create sentry/1.0.0` creates version `1.0.0` in org `sentry`. If your `Sentry.init()` uses `release: "1.0.0"`, this is correct. Don't double-prefix like `sentry/myapp/1.0.0`.
+- **Running `set-commits --auto` without a git checkout**: `--auto` needs a local git repo to discover the origin remote URL and HEAD commit. In CI, ensure `actions/checkout` with `fetch-depth: 0` runs before `set-commits --auto`.
+- **Using `sentry api` when CLI commands suffice**: `sentry issue list --json` already includes `shortId`, `title`, `priority`, `level`, `status`, `permalink`, and other fields at the top level. Some fields like `count`, `userCount`, `firstSeen`, and `lastSeen` may be null depending on the issue. Use `--fields` to select specific fields and `--help` to see all available fields. Only fall back to `sentry api` for data the CLI doesn't expose.
+
+## Prerequisites
+
+The CLI must be installed and authenticated before use.
+
+### Installation
+
+```bash
+curl https://cli.sentry.dev/install -fsS | bash
+curl https://cli.sentry.dev/install -fsS | bash -s -- --version nightly
+
+# Or install via npm/pnpm/bun
+npm install -g sentry
+```
+
+### Authentication
+
+```bash
+sentry auth login
+sentry auth login --token YOUR_SENTRY_API_TOKEN
+sentry auth status
+sentry auth logout
+```
+
+## Command Reference
+
+### Auth
+
+Authenticate with Sentry
+
+- `sentry auth login` — Authenticate with Sentry
+- `sentry auth logout` — Log out of Sentry
+- `sentry auth refresh` — Refresh your authentication token
+- `sentry auth status` — View authentication status
+- `sentry auth token` — Print the stored authentication token
+- `sentry auth whoami` — Show the currently authenticated user
+
+→ Full flags and examples: `references/auth.md`
+
+### Org
+
+Work with Sentry organizations
+
+- `sentry org list` — List organizations
+- `sentry org view <org>` — View details of an organization
+
+→ Full flags and examples: `references/org.md`
+
+### Project
+
+Work with Sentry projects
+
+- `sentry project create <name> <platform>` — Create a new project
+- `sentry project delete <org/project>` — Delete a project
+- `sentry project list <org/project>` — List projects
+- `sentry project view <org/project>` — View details of a project
+
+→ Full flags and examples: `references/project.md`
+
+### Issue
+
+Manage Sentry issues
+
+- `sentry issue list <org/project>` — List issues in a project
+- `sentry issue events <issue>` — List events for a specific issue
+- `sentry issue explain <issue>` — Analyze an issue's root cause using Seer AI
+- `sentry issue plan <issue>` — Generate a solution plan using Seer AI
+- `sentry issue view <issue>` — View details of a specific issue
+
+→ Full flags and examples: `references/issue.md`
+
+### Event
+
+View and list Sentry events
+
+- `sentry event view <org/project/event-id...>` — View details of a specific event
+- `sentry event list <issue>` — List events for an issue
+
+→ Full flags and examples: `references/event.md`
+
+### API
+
+Make an authenticated API request
+
+- `sentry api <endpoint>` — Make an authenticated API request
+
+→ Full flags and examples: `references/api.md`
+
+### CLI
+
+CLI-related commands
+
+- `sentry cli feedback <message...>` — Send feedback about the CLI
+- `sentry cli fix` — Diagnose and repair CLI database issues
+- `sentry cli setup` — Configure shell integration
+- `sentry cli upgrade <version>` — Update the Sentry CLI to the latest version
+
+→ Full flags and examples: `references/cli.md`
+
+### Dashboard
+
+Manage Sentry dashboards
+
+- `sentry dashboard list <org/title-filter...>` — List dashboards
+- `sentry dashboard view <org/project/dashboard...>` — View a dashboard
+- `sentry dashboard create <org/project/title...>` — Create a dashboard
+- `sentry dashboard widget add <org/project/dashboard/title...>` — Add a widget to a dashboard
+- `sentry dashboard widget edit <org/project/dashboard...>` — Edit a widget in a dashboard
+- `sentry dashboard widget delete <org/project/dashboard...>` — Delete a widget from a dashboard
+
+→ Full flags and examples: `references/dashboard.md`
+
+### Release
+
+Work with Sentry releases
+
+- `sentry release list <org/project>` — List releases
+- `sentry release view <org/version...>` — View release details
+- `sentry release create <org/version...>` — Create a release
+- `sentry release finalize <org/version...>` — Finalize a release
+- `sentry release delete <org/version...>` — Delete a release
+- `sentry release deploy <org/version environment name...>` — Create a deploy for a release
+- `sentry release deploys <org/version...>` — List deploys for a release
+- `sentry release set-commits <org/version...>` — Set commits for a release
+- `sentry release propose-version` — Propose a release version
+
+→ Full flags and examples: `references/release.md`
+
+### Repo
+
+Work with Sentry repositories
+
+- `sentry repo list <org/project>` — List repositories
+
+→ Full flags and examples: `references/repo.md`
+
+### Team
+
+Work with Sentry teams
+
+- `sentry team list <org/project>` — List teams
+
+→ Full flags and examples: `references/team.md`
+
+### Log
+
+View Sentry logs
+
+- `sentry log list <org/project-or-trace-id...>` — List logs from a project
+- `sentry log view <org/project/log-id...>` — View details of one or more log entries
+
+→ Full flags and examples: `references/log.md`
+
+### Sourcemap
+
+Manage sourcemaps
+
+- `sentry sourcemap inject <directory>` — Inject debug IDs into JavaScript files and sourcemaps
+- `sentry sourcemap upload <directory>` — Upload sourcemaps to Sentry
+
+→ Full flags and examples: `references/sourcemap.md`
+
+### Span
+
+List and view spans in projects or traces
+
+- `sentry span list <org/project/trace-id...>` — List spans in a project or trace
+- `sentry span view <trace-id/span-id...>` — View details of specific spans
+
+→ Full flags and examples: `references/span.md`
+
+### Trace
+
+View distributed traces
+
+- `sentry trace list <org/project>` — List recent traces in a project
+- `sentry trace view <org/project/trace-id...>` — View details of a specific trace
+- `sentry trace logs <org/trace-id...>` — View logs associated with a trace
+
+→ Full flags and examples: `references/trace.md`
+
+### Trial
+
+Manage product trials
+
+- `sentry trial list <org>` — List product trials
+- `sentry trial start <name> <org>` — Start a product trial
+
+→ Full flags and examples: `references/trial.md`
+
+### Init
+
+Initialize Sentry in your project (experimental)
+
+- `sentry init <target> <directory>` — Initialize Sentry in your project (experimental)
+
+→ Full flags and examples: `references/init.md`
+
+### Schema
+
+Browse the Sentry API schema
+
+- `sentry schema <resource...>` — Browse the Sentry API schema
+
+→ Full flags and examples: `references/schema.md`
+
+## Global Options
+
+All commands support the following global options:
+
+- `--help` - Show help for the command
+- `--version` - Show CLI version
+- `--log-level <level>` - Set log verbosity (`error`, `warn`, `log`, `info`, `debug`, `trace`). Overrides `SENTRY_LOG_LEVEL`
+- `--verbose` - Shorthand for `--log-level debug`
+
+## Output Formats
+
+### JSON Output
+
+Most list and view commands support `--json` flag for JSON output, making it easy to integrate with other tools:
+
+```bash
+sentry org list --json | jq '.[] | .slug'
+```
+
+### Opening in Browser
+
+View commands support `-w` or `--web` flag to open the resource in your browser:
+
+```bash
+sentry issue view PROJ-123 -w
+```

--- a/.claude/skills/sentry-cli/references/api.md
+++ b/.claude/skills/sentry-cli/references/api.md
@@ -1,0 +1,69 @@
+---
+name: sentry-cli-api
+version: 0.25.0
+description: Make an authenticated API request
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# API Commands
+
+Make an authenticated API request
+
+### `sentry api <endpoint>`
+
+Make an authenticated API request
+
+**Flags:**
+- `-X, --method <value> - The HTTP method for the request - (default: "GET")`
+- `-d, --data <value> - Inline JSON body for the request (like curl -d)`
+- `-F, --field <value>... - Add a typed parameter (key=value, key[sub]=value, key[]=value)`
+- `-f, --raw-field <value>... - Add a string parameter without JSON parsing`
+- `-H, --header <value>... - Add a HTTP request header in key:value format`
+- `--input <value> - The file to use as body for the HTTP request (use "-" to read from standard input)`
+- `--silent - Do not print the response body`
+- `--verbose - Include full HTTP request and response in the output`
+- `-n, --dry-run - Show the resolved request without sending it`
+
+**Examples:**
+
+```bash
+# List organizations
+sentry api organizations/
+
+# Get a specific issue
+sentry api issues/123456789/
+
+# Create a release
+sentry api organizations/my-org/releases/ \
+  -X POST -F version=1.0.0
+
+# With inline JSON body
+sentry api issues/123456789/ \
+  -X POST -d '{"status": "resolved"}'
+
+# Update an issue status
+sentry api issues/123456789/ \
+  -X PUT -F status=resolved
+
+# Assign an issue
+sentry api issues/123456789/ \
+  -X PUT --field assignedTo="user@example.com"
+
+sentry api projects/my-org/my-project/ -X DELETE
+
+# Add custom headers
+sentry api organizations/ -H "X-Custom: value"
+
+# Read body from a file
+sentry api projects/my-org/my-project/releases/ -X POST --input release.json
+
+# Verbose mode (shows full HTTP request/response)
+sentry api organizations/ --verbose
+
+# Preview the request without sending
+sentry api organizations/ --dry-run
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.claude/skills/sentry-cli/references/auth.md
+++ b/.claude/skills/sentry-cli/references/auth.md
@@ -1,0 +1,95 @@
+---
+name: sentry-cli-auth
+version: 0.25.0
+description: Authenticate with Sentry
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Auth Commands
+
+Authenticate with Sentry
+
+### `sentry auth login`
+
+Authenticate with Sentry
+
+**Flags:**
+- `--token <value> - Authenticate using an API token instead of OAuth`
+- `--timeout <value> - Timeout for OAuth flow in seconds (default: 900) - (default: "900")`
+- `--force - Re-authenticate without prompting`
+
+**Examples:**
+
+```bash
+sentry auth login
+
+sentry auth login --token YOUR_SENTRY_API_TOKEN
+
+SENTRY_URL=https://sentry.example.com sentry auth login
+
+SENTRY_URL=https://sentry.example.com sentry auth login --token YOUR_TOKEN
+```
+
+### `sentry auth logout`
+
+Log out of Sentry
+
+**Examples:**
+
+```bash
+sentry auth logout
+```
+
+### `sentry auth refresh`
+
+Refresh your authentication token
+
+**Flags:**
+- `--force - Force refresh even if token is still valid`
+
+**Examples:**
+
+```bash
+sentry auth refresh
+```
+
+### `sentry auth status`
+
+View authentication status
+
+**Flags:**
+- `--show-token - Show the stored token (masked by default)`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**Examples:**
+
+```bash
+sentry auth status
+
+# Show the raw token
+sentry auth status --show-token
+
+# View current user
+sentry auth whoami
+```
+
+### `sentry auth token`
+
+Print the stored authentication token
+
+**Examples:**
+
+```bash
+sentry auth token
+```
+
+### `sentry auth whoami`
+
+Show the currently authenticated user
+
+**Flags:**
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.claude/skills/sentry-cli/references/cli.md
+++ b/.claude/skills/sentry-cli/references/cli.md
@@ -1,0 +1,98 @@
+---
+name: sentry-cli-cli
+version: 0.25.0
+description: CLI-related commands
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# CLI Commands
+
+CLI-related commands
+
+### `sentry cli feedback <message...>`
+
+Send feedback about the CLI
+
+**Examples:**
+
+```bash
+# Send positive feedback
+sentry cli feedback i love this tool
+
+# Report an issue
+sentry cli feedback the issue view is confusing
+```
+
+### `sentry cli fix`
+
+Diagnose and repair CLI database issues
+
+**Flags:**
+- `--dry-run - Show what would be fixed without making changes`
+
+**Examples:**
+
+```bash
+sentry cli fix
+```
+
+### `sentry cli setup`
+
+Configure shell integration
+
+**Flags:**
+- `--install - Install the binary from a temp location to the system path`
+- `--method <value> - Installation method (curl, npm, pnpm, bun, yarn)`
+- `--channel <value> - Release channel to persist (stable or nightly)`
+- `--no-modify-path - Skip PATH modification`
+- `--no-completions - Skip shell completion installation`
+- `--no-agent-skills - Skip agent skill installation for AI coding assistants`
+- `--quiet - Suppress output (for scripted usage)`
+
+**Examples:**
+
+```bash
+# Run full setup (PATH, completions, agent skills)
+sentry cli setup
+
+# Skip agent skill installation
+sentry cli setup --no-agent-skills
+
+# Skip PATH and completion modifications
+sentry cli setup --no-modify-path --no-completions
+```
+
+### `sentry cli upgrade <version>`
+
+Update the Sentry CLI to the latest version
+
+**Flags:**
+- `--check - Check for updates without installing`
+- `--force - Force upgrade even if already on the latest version`
+- `--offline - Upgrade using only cached version info and patches (no network)`
+- `--method <value> - Installation method to use (curl, brew, npm, pnpm, bun, yarn)`
+
+**Examples:**
+
+```bash
+sentry cli upgrade --check
+
+# Upgrade to latest stable
+sentry cli upgrade
+
+# Upgrade to a specific version
+sentry cli upgrade 0.5.0
+
+# Force re-download
+sentry cli upgrade --force
+
+# Switch to nightly builds
+sentry cli upgrade nightly
+
+# Switch back to stable
+sentry cli upgrade stable
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.claude/skills/sentry-cli/references/dashboard.md
+++ b/.claude/skills/sentry-cli/references/dashboard.md
@@ -1,0 +1,169 @@
+---
+name: sentry-cli-dashboard
+version: 0.25.0
+description: Manage Sentry dashboards
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Dashboard Commands
+
+Manage Sentry dashboards
+
+### `sentry dashboard list <org/title-filter...>`
+
+List dashboards
+
+**Flags:**
+- `-w, --web - Open in browser`
+- `-n, --limit <value> - Maximum number of dashboards to list - (default: "25")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**Examples:**
+
+```bash
+# List all dashboards
+sentry dashboard list
+
+# Filter by name pattern
+sentry dashboard list "Backend*"
+
+# Open dashboard list in browser
+sentry dashboard list -w
+```
+
+### `sentry dashboard view <org/project/dashboard...>`
+
+View a dashboard
+
+**Flags:**
+- `-w, --web - Open in browser`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-r, --refresh <value> - Auto-refresh interval in seconds (default: 60, min: 10)`
+- `-t, --period <value> - Time range: "7d", "2026-03-07..2026-04-07", ">=2026-03-07"`
+
+**Examples:**
+
+```bash
+# View by title
+sentry dashboard view 'Frontend Performance'
+
+# View by ID
+sentry dashboard view 12345
+
+# Auto-refresh every 30 seconds
+sentry dashboard view "Backend Performance" --refresh 30
+
+# Open in browser
+sentry dashboard view 12345 -w
+```
+
+### `sentry dashboard create <org/project/title...>`
+
+Create a dashboard
+
+**Examples:**
+
+```bash
+sentry dashboard create 'Frontend Performance'
+```
+
+### `sentry dashboard widget add <org/project/dashboard/title...>`
+
+Add a widget to a dashboard
+
+**Flags:**
+- `-d, --display <value> - Display type (big_number, line, area, bar, table, stacked_area, top_n, text, categorical_bar, details, wheel, rage_and_dead_clicks, server_tree, agents_traces_table)`
+- `--dataset <value> - Widget dataset (default: spans)`
+- `-q, --query <value>... - Aggregate expression (e.g. count, p95:span.duration)`
+- `-w, --where <value> - Search conditions filter (e.g. is:unresolved)`
+- `-g, --group-by <value>... - Group-by column (repeatable)`
+- `-s, --sort <value> - Order by (prefix - for desc, e.g. -count)`
+- `-n, --limit <value> - Result limit`
+- `--x <value> - Grid column position (0-based, 0–5)`
+- `--y <value> - Grid row position (0-based)`
+- `--width <value> - Widget width in grid columns (1–6)`
+- `--height <value> - Widget height in grid rows (min 1)`
+
+**Examples:**
+
+```bash
+# Simple counter widget
+sentry dashboard widget add 'My Dashboard' "Error Count" \
+  --display big_number --query count
+
+# Line chart with group-by
+sentry dashboard widget add 'My Dashboard' "Errors by Browser" \
+  --display line --query count --group-by browser.name
+
+# Table with multiple aggregates, sorted descending
+sentry dashboard widget add 'My Dashboard' "Top Endpoints" \
+  --display table \
+  --query count --query p95:span.duration \
+  --group-by transaction \
+  --sort -count --limit 10
+
+# With search filter
+sentry dashboard widget add 'My Dashboard' "Slow Requests" \
+  --display bar --query p95:span.duration \
+  --where "span.op:http.client" \
+  --group-by span.description
+```
+
+### `sentry dashboard widget edit <org/project/dashboard...>`
+
+Edit a widget in a dashboard
+
+**Flags:**
+- `-i, --index <value> - Widget index (0-based)`
+- `-t, --title <value> - Widget title to match`
+- `--new-title <value> - New widget title`
+- `-d, --display <value> - Display type (big_number, line, area, bar, table, stacked_area, top_n, text, categorical_bar, details, wheel, rage_and_dead_clicks, server_tree, agents_traces_table)`
+- `--dataset <value> - Widget dataset (default: spans)`
+- `-q, --query <value>... - Aggregate expression (e.g. count, p95:span.duration)`
+- `-w, --where <value> - Search conditions filter (e.g. is:unresolved)`
+- `-g, --group-by <value>... - Group-by column (repeatable)`
+- `-s, --sort <value> - Order by (prefix - for desc, e.g. -count)`
+- `-n, --limit <value> - Result limit`
+- `--x <value> - Grid column position (0-based, 0–5)`
+- `--y <value> - Grid row position (0-based)`
+- `--width <value> - Widget width in grid columns (1–6)`
+- `--height <value> - Widget height in grid rows (min 1)`
+
+**Examples:**
+
+```bash
+# Change display type
+sentry dashboard widget edit 12345 --title 'Error Count' --display bar
+
+# Rename a widget
+sentry dashboard widget edit 'My Dashboard' --index 0 --new-title 'Total Errors'
+
+# Change the query
+sentry dashboard widget edit 12345 --title 'Error Rate' --query p95:span.duration
+```
+
+### `sentry dashboard widget delete <org/project/dashboard...>`
+
+Delete a widget from a dashboard
+
+**Flags:**
+- `-i, --index <value> - Widget index (0-based)`
+- `-t, --title <value> - Widget title to match`
+- `-y, --yes - Skip confirmation prompt`
+- `-f, --force - Force the operation without confirmation`
+- `-n, --dry-run - Show what would happen without making changes`
+
+**Examples:**
+
+```bash
+# Delete by title
+sentry dashboard widget delete 'My Dashboard' --title 'Error Count'
+
+# Delete by index
+sentry dashboard widget delete 12345 --index 2
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.claude/skills/sentry-cli/references/event.md
+++ b/.claude/skills/sentry-cli/references/event.md
@@ -1,0 +1,64 @@
+---
+name: sentry-cli-event
+version: 0.25.0
+description: View and list Sentry events
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Event Commands
+
+View and list Sentry events
+
+### `sentry event view <org/project/event-id...>`
+
+View details of a specific event
+
+**Flags:**
+- `-w, --web - Open in browser`
+- `--spans <value> - Span tree depth limit (number, "all" for unlimited, "no" to disable) - (default: "3")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+### `sentry event list <issue>`
+
+List events for an issue
+
+**Flags:**
+- `-n, --limit <value> - Number of events (1-1000) - (default: "25")`
+- `-q, --query <value> - Search query (Sentry search syntax)`
+- `--full - Include full event body (stacktraces)`
+- `-t, --period <value> - Time range: "7d", "2026-03-07..2026-04-07", ">=2026-03-07" - (default: "7d")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Internal event ID |
+| `event.type` | string | Event type (error, default, transaction) |
+| `groupID` | string \| null | Group (issue) ID |
+| `eventID` | string | UUID-format event ID |
+| `projectID` | string | Project ID |
+| `message` | string | Event message |
+| `title` | string | Event title |
+| `location` | string \| null | Source location (file:line) |
+| `culprit` | string \| null | Culprit function/module |
+| `user` | object \| null | User context |
+| `tags` | array | Event tags |
+| `platform` | string \| null | Platform (python, javascript, etc.) |
+| `dateCreated` | string | ISO 8601 creation timestamp |
+| `crashFile` | string \| null | Crash file URL |
+| `metadata` | unknown \| null | Event metadata |
+
+**Examples:**
+
+```bash
+sentry event view abc123def456abc123def456abc12345
+
+# Open in browser
+sentry event view abc123def456abc123def456abc12345 -w
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.claude/skills/sentry-cli/references/init.md
+++ b/.claude/skills/sentry-cli/references/init.md
@@ -1,0 +1,52 @@
+---
+name: sentry-cli-init
+version: 0.25.0
+description: Initialize Sentry in your project (experimental)
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Init Commands
+
+Initialize Sentry in your project (experimental)
+
+### `sentry init <target> <directory>`
+
+Initialize Sentry in your project (experimental)
+
+**Flags:**
+- `-y, --yes - Non-interactive mode (accept defaults)`
+- `-n, --dry-run - Show what would happen without making changes`
+- `--features <value>... - Features to enable: errors,tracing,logs,replay,metrics,profiling,sourcemaps,crons,ai-monitoring,user-feedback`
+- `-t, --team <value> - Team slug to create the project under`
+
+**Examples:**
+
+```bash
+# Interactive setup
+sentry init
+
+# Non-interactive with auto-yes
+sentry init -y
+
+# Dry run to preview changes
+sentry init --dry-run
+
+# Target a subdirectory
+sentry init ./my-app
+
+# Use a specific org (auto-detect project)
+sentry init acme/
+
+# Use a specific org and project
+sentry init acme/my-app
+
+# Assign a team when creating a new project
+sentry init acme/ --team backend
+
+# Enable specific features
+sentry init --features profiling,replay
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.claude/skills/sentry-cli/references/issue.md
+++ b/.claude/skills/sentry-cli/references/issue.md
@@ -1,0 +1,159 @@
+---
+name: sentry-cli-issue
+version: 0.25.0
+description: Manage Sentry issues
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Issue Commands
+
+Manage Sentry issues
+
+### `sentry issue list <org/project>`
+
+List issues in a project
+
+**Flags:**
+- `-q, --query <value> - Search query (Sentry search syntax)`
+- `-n, --limit <value> - Maximum number of issues to list - (default: "25")`
+- `-s, --sort <value> - Sort by: date, new, freq, user - (default: "date")`
+- `-t, --period <value> - Time range: "7d", "2026-03-07..2026-04-07", ">=2026-03-07" - (default: "90d")`
+- `-c, --cursor <value> - Pagination cursor (use "next" for next page, "prev" for previous)`
+- `--compact - Single-line rows for compact output (auto-detects if omitted)`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Numeric issue ID |
+| `shortId` | string | Human-readable short ID (e.g. PROJ-ABC) |
+| `title` | string | Issue title |
+| `culprit` | string | Culprit string |
+| `count` | string | Total event count |
+| `userCount` | number | Number of affected users |
+| `firstSeen` | string \| null | First occurrence (ISO 8601) |
+| `lastSeen` | string \| null | Most recent occurrence (ISO 8601) |
+| `level` | string | Severity level |
+| `status` | string | Issue status |
+| `priority` | string | Triage priority |
+| `platform` | string | Platform |
+| `permalink` | string | URL to the issue in Sentry |
+| `project` | object | Project info |
+| `metadata` | object | Issue metadata |
+| `assignedTo` | unknown \| null | Assigned user or team |
+| `substatus` | string \| null | Issue substatus |
+| `isUnhandled` | boolean | Whether the issue is unhandled |
+| `seerFixabilityScore` | number \| null | Seer AI fixability score (0-1) |
+
+**Examples:**
+
+```bash
+# List issues in a specific project
+sentry issue list my-org/frontend
+
+# All projects in an org
+sentry issue list my-org/
+
+# Search for a project across organizations
+sentry issue list frontend
+
+# Show only unresolved issues
+sentry issue list my-org/frontend --query "is:unresolved"
+
+# Show resolved issues
+sentry issue list my-org/frontend --query "is:resolved"
+
+# Sort by frequency
+sentry issue list my-org/frontend --sort freq --limit 20
+```
+
+### `sentry issue events <issue>`
+
+List events for a specific issue
+
+**Flags:**
+- `-n, --limit <value> - Number of events (1-1000) - (default: "25")`
+- `-q, --query <value> - Search query (Sentry search syntax)`
+- `--full - Include full event body (stacktraces)`
+- `-t, --period <value> - Time range: "7d", "2026-03-07..2026-04-07", ">=2026-03-07" - (default: "7d")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Internal event ID |
+| `event.type` | string | Event type (error, default, transaction) |
+| `groupID` | string \| null | Group (issue) ID |
+| `eventID` | string | UUID-format event ID |
+| `projectID` | string | Project ID |
+| `message` | string | Event message |
+| `title` | string | Event title |
+| `location` | string \| null | Source location (file:line) |
+| `culprit` | string \| null | Culprit function/module |
+| `user` | object \| null | User context |
+| `tags` | array | Event tags |
+| `platform` | string \| null | Platform (python, javascript, etc.) |
+| `dateCreated` | string | ISO 8601 creation timestamp |
+| `crashFile` | string \| null | Crash file URL |
+| `metadata` | unknown \| null | Event metadata |
+
+### `sentry issue explain <issue>`
+
+Analyze an issue's root cause using Seer AI
+
+**Flags:**
+- `--force - Force new analysis even if one exists`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**Examples:**
+
+```bash
+# Analyze root cause (may take a few minutes for new issues)
+sentry issue explain 123456789
+
+# By short ID with org prefix
+sentry issue explain my-org/MYPROJECT-ABC
+
+# Force a fresh analysis
+sentry issue explain 123456789 --force
+
+# Generate a fix plan (requires explain to be run first)
+sentry issue plan 123456789
+
+# Specify which root cause to plan for
+sentry issue plan 123456789 --cause 0
+```
+
+### `sentry issue plan <issue>`
+
+Generate a solution plan using Seer AI
+
+**Flags:**
+- `--cause <value> - Root cause ID to plan (required if multiple causes exist)`
+- `--force - Force new plan even if one exists`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+### `sentry issue view <issue>`
+
+View details of a specific issue
+
+**Flags:**
+- `-w, --web - Open in browser`
+- `--spans <value> - Span tree depth limit (number, "all" for unlimited, "no" to disable) - (default: "3")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**Examples:**
+
+```bash
+sentry issue view FRONT-ABC
+
+# Open in browser
+sentry issue view FRONT-ABC -w
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.claude/skills/sentry-cli/references/log.md
+++ b/.claude/skills/sentry-cli/references/log.md
@@ -1,0 +1,84 @@
+---
+name: sentry-cli-log
+version: 0.25.0
+description: View Sentry logs
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Log Commands
+
+View Sentry logs
+
+### `sentry log list <org/project-or-trace-id...>`
+
+List logs from a project
+
+**Flags:**
+- `-n, --limit <value> - Number of log entries (1-1000) - (default: "100")`
+- `-q, --query <value> - Filter query (Sentry search syntax)`
+- `-f, --follow <value> - Stream logs (optionally specify poll interval in seconds)`
+- `-t, --period <value> - Time range: "7d", "2026-03-07..2026-04-07", ">=2026-03-07"`
+- `-s, --sort <value> - Sort order: "newest" (default) or "oldest" - (default: "newest")`
+- `--fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sentry.item_id` | string | Unique log entry ID |
+| `timestamp` | string | Log timestamp (ISO 8601) |
+| `timestamp_precise` | number | Nanosecond-precision timestamp |
+| `message` | string \| null | Log message |
+| `severity` | string \| null | Severity level (error, warning, info, debug) |
+| `trace` | string \| null | Trace ID for correlation |
+
+**Examples:**
+
+```bash
+# List last 100 logs (default)
+sentry log list
+
+# Show only error logs
+sentry log list -q 'level:error'
+
+# Filter by message content
+sentry log list -q 'database'
+
+# Limit results
+sentry log list --limit 50
+
+# Stream with default 2-second poll interval
+sentry log list -f
+
+# Stream with custom 5-second poll interval
+sentry log list -f 5
+
+# Stream error logs from a specific project
+sentry log list my-org/backend -f -q 'level:error'
+
+sentry log list --json | jq '.data[] | select(.severity == "error")'
+```
+
+### `sentry log view <org/project/log-id...>`
+
+View details of one or more log entries
+
+**Flags:**
+- `-w, --web - Open in browser`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**Examples:**
+
+```bash
+sentry log view 968c763c740cfda8b6728f27fb9e9b01
+
+# With explicit project
+sentry log view my-org/backend 968c763c740cfda8b6728f27fb9e9b01
+
+# Open in browser
+sentry log view 968c763c740cfda8b6728f27fb9e9b01 -w
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.claude/skills/sentry-cli/references/org.md
+++ b/.claude/skills/sentry-cli/references/org.md
@@ -1,0 +1,46 @@
+---
+name: sentry-cli-org
+version: 0.25.0
+description: Work with Sentry organizations
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Org Commands
+
+Work with Sentry organizations
+
+### `sentry org list`
+
+List organizations
+
+**Flags:**
+- `-n, --limit <value> - Maximum number of organizations to list - (default: "25")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+### `sentry org view <org>`
+
+View details of an organization
+
+**Flags:**
+- `-w, --web - Open in browser`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**Examples:**
+
+```bash
+# List organizations
+sentry org list
+
+# View organization details
+sentry org view my-org
+
+# Open in browser
+sentry org view my-org -w
+
+# JSON output
+sentry org list --json
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.claude/skills/sentry-cli/references/project.md
+++ b/.claude/skills/sentry-cli/references/project.md
@@ -1,0 +1,88 @@
+---
+name: sentry-cli-project
+version: 0.25.0
+description: Work with Sentry projects
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Project Commands
+
+Work with Sentry projects
+
+### `sentry project create <name> <platform>`
+
+Create a new project
+
+**Flags:**
+- `-t, --team <value> - Team to create the project under`
+- `-n, --dry-run - Show what would happen without making changes`
+
+**Examples:**
+
+```bash
+# Create a new project
+sentry project create my-new-app javascript-nextjs
+
+# Create under a specific org and team
+sentry project create my-org/my-new-app python --team backend-team
+
+# Preview without creating
+sentry project create my-new-app node --dry-run
+```
+
+### `sentry project delete <org/project>`
+
+Delete a project
+
+**Flags:**
+- `-y, --yes - Skip confirmation prompt`
+- `-f, --force - Force the operation without confirmation`
+- `-n, --dry-run - Show what would happen without making changes`
+
+**Examples:**
+
+```bash
+# Delete a project (will prompt for confirmation)
+sentry project delete my-org/old-project
+
+# Delete without confirmation
+sentry project delete my-org/old-project --yes
+```
+
+### `sentry project list <org/project>`
+
+List projects
+
+**Flags:**
+- `-n, --limit <value> - Maximum number of projects to list - (default: "25")`
+- `-p, --platform <value> - Filter by platform (e.g., javascript, python)`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+### `sentry project view <org/project>`
+
+View details of a project
+
+**Flags:**
+- `-w, --web - Open in browser`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**Examples:**
+
+```bash
+# List all projects in an org
+sentry project list my-org/
+
+# Filter by platform
+sentry project list my-org/ --platform javascript
+
+# View project details
+sentry project view my-org/frontend
+
+# Open project in browser
+sentry project view my-org/frontend -w
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.claude/skills/sentry-cli/references/release.md
+++ b/.claude/skills/sentry-cli/references/release.md
@@ -1,0 +1,131 @@
+---
+name: sentry-cli-release
+version: 0.25.0
+description: Work with Sentry releases
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Release Commands
+
+Work with Sentry releases
+
+### `sentry release list <org/project>`
+
+List releases
+
+**Flags:**
+- `-n, --limit <value> - Maximum number of releases to list - (default: "25")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+### `sentry release view <org/version...>`
+
+View release details
+
+**Flags:**
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+### `sentry release create <org/version...>`
+
+Create a release
+
+**Flags:**
+- `-p, --project <value> - Associate with project(s), comma-separated`
+- `--finalize - Immediately finalize the release (set dateReleased)`
+- `--ref <value> - Git ref (branch or tag name)`
+- `--url <value> - URL to the release source`
+- `-n, --dry-run - Show what would happen without making changes`
+
+### `sentry release finalize <org/version...>`
+
+Finalize a release
+
+**Flags:**
+- `--released <value> - Custom release timestamp (ISO 8601). Defaults to now.`
+- `--url <value> - URL for the release`
+- `-n, --dry-run - Show what would happen without making changes`
+
+### `sentry release delete <org/version...>`
+
+Delete a release
+
+**Flags:**
+- `-y, --yes - Skip confirmation prompt`
+- `-f, --force - Force the operation without confirmation`
+- `-n, --dry-run - Show what would happen without making changes`
+
+### `sentry release deploy <org/version environment name...>`
+
+Create a deploy for a release
+
+**Flags:**
+- `--url <value> - URL for the deploy`
+- `--started <value> - Deploy start time (ISO 8601)`
+- `--finished <value> - Deploy finish time (ISO 8601)`
+- `-t, --time <value> - Deploy duration in seconds (sets started = now - time, finished = now)`
+- `-n, --dry-run - Show what would happen without making changes`
+
+### `sentry release deploys <org/version...>`
+
+List deploys for a release
+
+### `sentry release set-commits <org/version...>`
+
+Set commits for a release
+
+**Flags:**
+- `--auto - Auto-discover commits via repository integration (needs local git checkout)`
+- `--local - Read commits from local git history`
+- `--clear - Clear all commits from the release`
+- `--commit <value> - Explicit commit as REPO@SHA or REPO@PREV..SHA (comma-separated)`
+- `--initial-depth <value> - Number of commits to read with --local - (default: "20")`
+
+### `sentry release propose-version`
+
+Propose a release version
+
+**Examples:**
+
+```bash
+# List releases (auto-detect org)
+sentry release list
+
+# List releases in a specific org
+sentry release list my-org/
+
+# View release details
+sentry release view 1.0.0
+sentry release view my-org/1.0.0
+
+# Create and finalize a release
+sentry release create 1.0.0 --finalize
+
+# Create a release, then finalize separately
+sentry release create 1.0.0
+sentry release set-commits 1.0.0 --auto
+sentry release finalize 1.0.0
+
+# Set commits from local git history
+sentry release set-commits 1.0.0 --local
+
+# Create a deploy
+sentry release deploy 1.0.0 production
+sentry release deploy 1.0.0 staging "Deploy #42"
+
+# Propose a version from git HEAD
+sentry release create $(sentry release propose-version)
+
+# Output as JSON
+sentry release list --json
+sentry release view 1.0.0 --json
+
+# Full release workflow with explicit org
+sentry release create my-org/1.0.0 --project my-project
+sentry release set-commits my-org/1.0.0 --auto
+sentry release finalize my-org/1.0.0
+sentry release deploy my-org/1.0.0 production
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.claude/skills/sentry-cli/references/repo.md
+++ b/.claude/skills/sentry-cli/references/repo.md
@@ -1,0 +1,50 @@
+---
+name: sentry-cli-repo
+version: 0.25.0
+description: Work with Sentry repositories
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Repo Commands
+
+Work with Sentry repositories
+
+### `sentry repo list <org/project>`
+
+List repositories
+
+**Flags:**
+- `-n, --limit <value> - Maximum number of repositories to list - (default: "25")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Repository ID |
+| `name` | string | Repository name |
+| `url` | string \| null | Repository URL |
+| `provider` | object | Version control provider |
+| `status` | string | Integration status |
+| `dateCreated` | string | Creation date (ISO 8601) |
+| `integrationId` | string | Integration ID |
+| `externalSlug` | string \| null | External slug (e.g. org/repo) |
+| `externalId` | string \| null | External ID |
+
+**Examples:**
+
+```bash
+# List repositories (auto-detect org)
+sentry repo list
+
+# List repos in a specific org with pagination
+sentry repo list my-org/ -c next
+
+# Output as JSON
+sentry repo list --json
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.claude/skills/sentry-cli/references/schema.md
+++ b/.claude/skills/sentry-cli/references/schema.md
@@ -1,0 +1,41 @@
+---
+name: sentry-cli-schema
+version: 0.25.0
+description: Browse the Sentry API schema
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Schema Commands
+
+Browse the Sentry API schema
+
+### `sentry schema <resource...>`
+
+Browse the Sentry API schema
+
+**Flags:**
+- `--all - Show all endpoints in a flat list`
+- `-q, --search <value> - Search endpoints by keyword`
+
+**Examples:**
+
+```bash
+# List all API resources
+sentry schema
+
+# Browse issue endpoints
+sentry schema issues
+
+# View details for a specific operation
+sentry schema issues list
+
+# Search for monitoring-related endpoints
+sentry schema --search monitor
+
+# Flat list of every endpoint
+sentry schema --all
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.claude/skills/sentry-cli/references/sourcemap.md
+++ b/.claude/skills/sentry-cli/references/sourcemap.md
@@ -1,0 +1,56 @@
+---
+name: sentry-cli-sourcemap
+version: 0.25.0
+description: Manage sourcemaps
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Sourcemap Commands
+
+Manage sourcemaps
+
+### `sentry sourcemap inject <directory>`
+
+Inject debug IDs into JavaScript files and sourcemaps
+
+**Flags:**
+- `--ext <value> - Comma-separated file extensions to process (default: .js,.cjs,.mjs)`
+- `--dry-run - Show what would be modified without writing`
+
+**Examples:**
+
+```bash
+# Inject debug IDs into all JS files in dist/
+sentry sourcemap inject ./dist
+
+# Preview changes without writing
+sentry sourcemap inject ./dist --dry-run
+
+# Only process specific extensions
+sentry sourcemap inject ./build --ext .js,.mjs
+```
+
+### `sentry sourcemap upload <directory>`
+
+Upload sourcemaps to Sentry
+
+**Flags:**
+- `--release <value> - Release version to associate with the upload`
+- `--url-prefix <value> - URL prefix for uploaded files (default: ~/) - (default: "~/")`
+
+**Examples:**
+
+```bash
+# Upload sourcemaps from dist/
+sentry sourcemap upload ./dist
+
+# Associate with a release
+sentry sourcemap upload ./dist --release 1.0.0
+
+# Set a custom URL prefix
+sentry sourcemap upload ./dist --url-prefix '~/static/js/'
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.claude/skills/sentry-cli/references/span.md
+++ b/.claude/skills/sentry-cli/references/span.md
@@ -1,0 +1,80 @@
+---
+name: sentry-cli-span
+version: 0.25.0
+description: List and view spans in projects or traces
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Span Commands
+
+List and view spans in projects or traces
+
+### `sentry span list <org/project/trace-id...>`
+
+List spans in a project or trace
+
+**Flags:**
+- `-n, --limit <value> - Number of spans (<=1000) - (default: "25")`
+- `-q, --query <value> - Filter spans (e.g., "op:db", "duration:>100ms", "project:backend")`
+- `-s, --sort <value> - Sort order: date, duration - (default: "date")`
+- `-t, --period <value> - Time range: "7d", "2026-03-07..2026-04-07", ">=2026-03-07" - (default: "7d")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Span ID |
+| `parent_span` | string \| null | Parent span ID |
+| `span.op` | string \| null | Span operation (e.g. http.client, db) |
+| `description` | string \| null | Span description |
+| `span.duration` | number \| null | Duration (ms) |
+| `timestamp` | string | Timestamp (ISO 8601) |
+| `project` | string | Project slug |
+| `transaction` | string \| null | Transaction name |
+| `trace` | string | Trace ID |
+
+**Examples:**
+
+```bash
+# List recent spans in the current project
+sentry span list
+
+# Find all DB spans
+sentry span list -q "op:db"
+
+# Slow spans in the last 24 hours
+sentry span list -q "duration:>100ms" --period 24h
+
+# List spans within a specific trace
+sentry span list abc123def456abc123def456abc12345
+
+# Paginate through results
+sentry span list -c next
+```
+
+### `sentry span view <trace-id/span-id...>`
+
+View details of specific spans
+
+**Flags:**
+- `--spans <value> - Span tree depth limit (number, "all" for unlimited, "no" to disable) - (default: "3")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**Examples:**
+
+```bash
+# View a single span
+sentry span view abc123def456abc123def456abc12345 a1b2c3d4e5f67890
+
+# View multiple spans at once
+sentry span view abc123def456abc123def456abc12345 a1b2c3d4e5f67890 b2c3d4e5f6789012
+
+# With explicit org/project
+sentry span view my-org/backend/abc123def456abc123def456abc12345 a1b2c3d4e5f67890
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.claude/skills/sentry-cli/references/team.md
+++ b/.claude/skills/sentry-cli/references/team.md
@@ -1,0 +1,48 @@
+---
+name: sentry-cli-team
+version: 0.25.0
+description: Work with Sentry teams
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Team Commands
+
+Work with Sentry teams
+
+### `sentry team list <org/project>`
+
+List teams
+
+**Flags:**
+- `-n, --limit <value> - Maximum number of teams to list - (default: "25")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Team ID |
+| `slug` | string | Team slug |
+| `name` | string | Team name |
+| `dateCreated` | string | Creation date (ISO 8601) |
+| `isMember` | boolean | Whether you are a member |
+| `teamRole` | string \| null | Your role in the team |
+| `memberCount` | number | Number of members |
+
+**Examples:**
+
+```bash
+# List teams
+sentry team list my-org/
+
+# Paginate through teams
+sentry team list my-org/ -c next
+
+# Output as JSON
+sentry team list --json
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.claude/skills/sentry-cli/references/trace.md
+++ b/.claude/skills/sentry-cli/references/trace.md
@@ -1,0 +1,100 @@
+---
+name: sentry-cli-trace
+version: 0.25.0
+description: View distributed traces
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Trace Commands
+
+View distributed traces
+
+### `sentry trace list <org/project>`
+
+List recent traces in a project
+
+**Flags:**
+- `-n, --limit <value> - Number of traces (1-1000) - (default: "25")`
+- `-q, --query <value> - Search query (Sentry search syntax)`
+- `-s, --sort <value> - Sort by: date, duration - (default: "date")`
+- `-t, --period <value> - Time range: "7d", "2026-03-07..2026-04-07", ">=2026-03-07" - (default: "7d")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `trace` | string | Trace ID |
+| `id` | string | Event ID |
+| `transaction` | string | Transaction name |
+| `timestamp` | string | Timestamp (ISO 8601) |
+| `transaction.duration` | number | Duration (ms) |
+| `project` | string | Project slug |
+
+**Examples:**
+
+```bash
+# List last 20 traces (default)
+sentry trace list
+
+# Sort by slowest first
+sentry trace list --sort duration
+
+# Filter by transaction name, last 24 hours
+sentry trace list -q "transaction:GET /api/users" --period 24h
+
+# Paginate through results
+sentry trace list my-org/backend -c next
+```
+
+### `sentry trace view <org/project/trace-id...>`
+
+View details of a specific trace
+
+**Flags:**
+- `-w, --web - Open in browser`
+- `--spans <value> - Span tree depth limit (number, "all" for unlimited, "no" to disable) - (default: "3")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**Examples:**
+
+```bash
+# View trace details with span tree
+sentry trace view abc123def456abc123def456abc12345
+
+# Open trace in browser
+sentry trace view abc123def456abc123def456abc12345 -w
+
+# Auto-recover from an issue short ID
+sentry trace view PROJ-123
+```
+
+### `sentry trace logs <org/trace-id...>`
+
+View logs associated with a trace
+
+**Flags:**
+- `-w, --web - Open trace in browser`
+- `-t, --period <value> - Time range: "7d", "2026-03-07..2026-04-07", ">=2026-03-07" - (default: "14d")`
+- `-n, --limit <value> - Number of log entries (<=1000) - (default: "100")`
+- `-q, --query <value> - Additional filter query (Sentry search syntax)`
+- `-s, --sort <value> - Sort order: "newest" (default) or "oldest" - (default: "newest")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+
+**Examples:**
+
+```bash
+# View logs for a trace
+sentry trace logs abc123def456abc123def456abc12345
+
+# Search with a longer time window
+sentry trace logs --period 30d abc123def456abc123def456abc12345
+
+# Filter logs within a trace
+sentry trace logs -q 'level:error' abc123def456abc123def456abc12345
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.claude/skills/sentry-cli/references/trial.md
+++ b/.claude/skills/sentry-cli/references/trial.md
@@ -1,0 +1,52 @@
+---
+name: sentry-cli-trial
+version: 0.25.0
+description: Manage product trials
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Trial Commands
+
+Manage product trials
+
+### `sentry trial list <org>`
+
+List product trials
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `category` | string | Trial category (e.g. seerUsers, seerAutofix) |
+| `startDate` | string \| null | Start date (ISO 8601) |
+| `endDate` | string \| null | End date (ISO 8601) |
+| `reasonCode` | number | Reason code |
+| `isStarted` | boolean | Whether the trial has started |
+| `lengthDays` | number \| null | Trial duration in days |
+
+### `sentry trial start <name> <org>`
+
+Start a product trial
+
+**Examples:**
+
+```bash
+# List all trials for the current org
+sentry trial list
+
+# List trials for a specific org
+sentry trial list my-org
+
+# Start a Seer trial
+sentry trial start seer
+
+# Start a trial for a specific org
+sentry trial start replays my-org
+
+# Start a Business plan trial (opens browser)
+sentry trial start plan
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/.zshrc
+++ b/.zshrc
@@ -960,3 +960,6 @@ export PATH="$HOME/.local/bin:$PATH"
 # bun
 export BUN_INSTALL="$HOME/.bun"
 export PATH="$BUN_INSTALL/bin:$PATH"
+
+# sentry
+fpath=("/Users/takuma/.local/share/zsh/site-functions" $fpath)

--- a/.zshrc
+++ b/.zshrc
@@ -962,4 +962,4 @@ export BUN_INSTALL="$HOME/.bun"
 export PATH="$BUN_INSTALL/bin:$PATH"
 
 # sentry
-fpath=("/Users/takuma/.local/share/zsh/site-functions" $fpath)
+fpath=("$HOME/.local/share/zsh/site-functions" $fpath)


### PR DESCRIPTION
## Summary

Sentry CLI をコマンドラインから操作するための包括的なスキルを追加。Issue調査、トレース分析、リリース管理など主要リソースのリファレンスドキュメントを含む。

## Changes

- **sentry-cli/SKILL.md**: メインスキル定義（エージェント向けガイダンス、設計原則、ワークフロー例）
- **sentry-cli/references/**: 各リソース別リファレンスドキュメント（19ファイル）
  - `issue.md`, `trace.md`, `event.md` — 障害調査系
  - `release.md`, `sourcemap.md` — リリース管理系
  - `api.md`, `schema.md` — API操作系
  - `auth.md`, `cli.md`, `init.md` — セットアップ系
  - `org.md`, `project.md`, `team.md`, `repo.md` — 組織管理系
  - `dashboard.md`, `log.md`, `span.md` — 可観測性系
  - `trial.md` — トライアル管理
- **.zshrc**: Sentry CLI の zsh 補完パスを追加

## Commits

- `01cfbfe` feat(skills): add sentry-cli skill with reference docs

## Files Changed

- Added: 19 files (`.claude/skills/sentry-cli/`)
- Modified: 1 file (`.zshrc`)

## Testing

- [ ] `/sentry-cli` スキルが認識されることを確認
- [ ] `sentry` コマンドの zsh 補完が動作することを確認
- [ ] リファレンスドキュメントの内容が正確であることを確認