### PR TITLE
feat(skills): add rename-tab for surface identification in cmux-agent and cmux-team

### DIFF
--- a/.claude/skills/cmux-agent/SKILL.md
+++ b/.claude/skills/cmux-agent/SKILL.md
@@ -33,10 +33,13 @@ WS=$(cmux --json new-workspace "$TASK_NAME" | jq -r '.workspace')
 # 2. Get the surface in the new workspace
 S=$(cmux --json list-pane-surfaces --workspace "$WS" | jq -r '.[0].surface')
 
-# 3. Launch Claude Code (headless, skip permissions for autonomous execution)
+# 3. Label the tab with surface ref for identification
+cmux rename-tab --surface "$S" "$S $TASK_NAME"
+
+# 4. Launch Claude Code (headless, skip permissions for autonomous execution)
 cmux send --surface "$S" "claude --dangerously-skip-permissions\n"
 
-# 4. Wait for Claude to be ready (prompt detection)
+# 5. Wait for Claude to be ready (prompt detection)
 for i in $(seq 1 30); do
   SCREEN=$(cmux read-screen --surface "$S" --lines 5)
   if echo "$SCREEN" | grep -qE '(>|❯|claude)'; then
@@ -45,7 +48,7 @@ for i in $(seq 1 30); do
   sleep 1
 done
 
-# 5. Send the task prompt
+# 6. Send the task prompt
 cmux send --surface "$S" "${PROMPT}"
 cmux send-key --surface "$S" return
 
@@ -81,6 +84,7 @@ Other skills can spawn sub-agents by running the commands directly:
 TASK_NAME="review-auth"
 WS=$(cmux --json new-workspace "$TASK_NAME" | jq -r '.workspace')
 S=$(cmux --json list-pane-surfaces --workspace "$WS" | jq -r '.[0].surface')
+cmux rename-tab --surface "$S" "$S $TASK_NAME"
 cmux send --surface "$S" "claude --dangerously-skip-permissions\n"
 sleep 5
 cmux send --surface "$S" "Review the auth middleware for security issues\n"
@@ -100,6 +104,7 @@ for TASK in "review models/" "review controllers/" "review middleware/"; do
   TASK_NAME="review-$(echo "$TASK" | tr ' /' '-')"
   WS=$(cmux --json new-workspace "$TASK_NAME" | jq -r '.workspace')
   S=$(cmux --json list-pane-surfaces --workspace "$WS" | jq -r '.[0].surface')
+  cmux rename-tab --surface "$S" "$S $TASK_NAME"
   cmux send --surface "$S" "claude --dangerously-skip-permissions\n"
   sleep 5
   cmux send --surface "$S" "${TASK}\n"

--- a/.claude/skills/cmux-team/SKILL.md
+++ b/.claude/skills/cmux-team/SKILL.md
@@ -76,6 +76,7 @@ TASK
 ```bash
 WS=$(cmux --json new-workspace "team-manager" | jq -r '.workspace')
 S=$(cmux --json list-pane-surfaces --workspace "$WS" | jq -r '.[0].surface')
+cmux rename-tab --surface "$S" "$S manager"
 cmux send --surface "$S" "claude --dangerously-skip-permissions\n"
 sleep 5
 cmux send --surface "$S" "$(cat <<'PROMPT'
@@ -132,6 +133,7 @@ git worktree add "$WORKTREE" -b "$BRANCH" 2>/dev/null || git worktree add "$WORK
 # 2. Spawn Agent in new workspace
 WS=$(cmux --json new-workspace "agent-$TASK_ID" | jq -r '.workspace')
 S=$(cmux --json list-pane-surfaces --workspace "$WS" | jq -r '.[0].surface')
+cmux rename-tab --surface "$S" "$S agent-$TASK_ID"
 cmux send --surface "$S" "cd $WORKTREE && claude --dangerously-skip-permissions\n"
 sleep 5
 

--- a/.claude/skills/cmux-team/references/conductor.md
+++ b/.claude/skills/cmux-team/references/conductor.md
@@ -45,7 +45,8 @@ log "Worktree created at $WORKTREE"
 # --- 3. Spawn Agent in new workspace ---
 WS=$(cmux --json new-workspace "agent-$TASK_ID" | jq -r '.workspace')
 S=$(cmux --json list-pane-surfaces --workspace "$WS" | jq -r '.[0].surface')
-log "Workspace $WS, surface $S"
+cmux rename-tab --surface "$S" "$S agent-$TASK_ID"
+log "Workspace $WS, surface $S (tab labeled)"
 
 WORKTREE_ABS=$(cd "$WORKTREE" && pwd)
 cmux send --surface "$S" "cd ${WORKTREE_ABS} && claude --dangerously-skip-permissions\n"


### PR DESCRIPTION
## Summary

cmux-agent / cmux-team でワークスペース作成時に `cmux rename-tab` を実行し、タブにsurface番号 + タスク名を自動表示する。

## Changes

- **cmux-agent**: Spawn Sequence、Programmatic Usage、Multi-Agent Pattern に `cmux rename-tab` 追加
- **cmux-team**: Manager起動、Conductor概要に `cmux rename-tab` 追加
- **cmux-team/references/conductor.md**: フルスクリプトに `cmux rename-tab` 追加

## Testing
- [ ] cmux環境内で `cmux rename-tab` の動作確認
- [ ] 複数エージェント起動時のタブ表示確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workspace tabs are now automatically labeled with role and task identifiers during agent spawning and manager launches.

* **Documentation**
  * Updated agent spawn procedures with tab naming steps.
  * Updated manager launch sequences with role-specific tab labeling.
  * Updated conductor procedures with agent task-specific tab identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->