### PR TITLE
feat(claude): Adapt to claude -p subscription policy changes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -93,6 +93,37 @@ EOF
 - 修正・リファクタリングの実行
 - 最終仕上げ・ポリッシュ
 
+## `claude -p` (非対話モード) のサブスクリプション対象外化への対応
+
+Claude Code Max サブスクリプションは `claude -p` / `claude --print` の呼び出しを対象外とし、API クレジットでの個別課金となる方針。dotfiles ではこれを抑制するため以下の運用ルールを設ける。
+
+### 代替方針
+
+- **Skill 内部で `claude -p` を呼ぶ場合** → Claude Code の **agent (Task ツールの `subagent_type` 指定)** で代替する。同一セッション内で実行されサブスク内で完結
+- **Skill 外の script (Python/TS/sh) で `claude -p` を spawn する場合** → **codex CLI** (`codex exec`) に置換する。テキスト生成用途なら意味的に等価
+- **claude の挙動自体を測る script** (skill-creator/run_eval.py, vercel/benchmark-runner.ts 等) は codex 置換できないため、`CLAUDE_ALLOW_PRINT=1` の環境変数で **明示 opt-in** したときのみ動作させる
+- **対話モード** (`claude --dangerously-skip-permissions`、cmux-agent 経由) は対象外 → サブスク内のまま
+
+### 予防策
+
+- `~/.claude/hooks/guard.sh` が Bash ツールで `claude -p` / `claude --print` を BLOCK する
+- 例外的に許可したい場合のみ `CLAUDE_ALLOW_PRINT=1` を環境変数に付与
+- BLOCK ログは `~/.claude/logs/guard-YYYY-MM-DD.jsonl` に記録される
+
+### プラグインキャッシュ向けパッチ運用
+
+外部プラグイン (skill-creator / vercel) のキャッシュ配下に `claude -p` が残っているため、`tools/patches/apply.sh` で書き換える：
+
+```bash
+make patches    # または bash tools/patches/apply.sh
+```
+
+- 冪等動作。再実行しても二重適用しない（marker チェック）
+- プラグインアップデートでパッチが上書きされたら再実行する
+- 必要環境変数:
+  - codex CLI 認証: `codex login` を済ませる、または `OPENAI_API_KEY` を設定
+  - 明示 opt-in で API 課金を許容する場合は `CLAUDE_ALLOW_PRINT=1`
+
 ## cmux Integration
 
 cmux 内で実行中の場合、cmux系スキルを活用してマルチペイン・マルチエージェント操作を行う。

--- a/.claude/hooks/guard.sh
+++ b/.claude/hooks/guard.sh
@@ -70,6 +70,18 @@ case "$TOOL_NAME" in
       exit 2
     fi
 
+    # === BLOCK: claude -p / --print (サブスク対象外、API 課金) ===
+    # 対話モード (claude --dangerously-skip-permissions など) は -p を含まないので素通り。
+    # 明示的に許可したい場合のみ CLAUDE_ALLOW_PRINT=1 を付与する。
+    if echo "$CMD" | grep -qE '(^|[[:space:]|;&])claude([[:space:]]+[^|;&]*)?[[:space:]]+(-p|--print)([[:space:]]|$)'; then
+      if [ "${CLAUDE_ALLOW_PRINT:-0}" != "1" ]; then
+        log_event "BLOCK" "claude-print-mode" "$CMD"
+        echo "BLOCKED: claude -p / --print はサブスクリプション対象外（API 課金）です。Skill 内なら Task ツールで agent 起動、外部 script なら codex CLI を検討。明示許可は CLAUDE_ALLOW_PRINT=1: $CMD" >&2
+        exit 2
+      fi
+      log_event "WARN" "claude-print-mode-allowed" "$CMD"
+    fi
+
     # === WARN: 本番系キーワード ===
     if echo "$CMD" | grep -qiE '(production|prod)\s.*(deploy|push|release)'; then
       log_event "WARN" "production-operation" "$CMD"

--- a/.claude/skills/measure-context.md
+++ b/.claude/skills/measure-context.md
@@ -1,12 +1,14 @@
 ---
 name: measure-context
-description: "初期コンテキストのトークン消費量を計測する。CLAUDE.md最適化の前後比較に使用。任意のリポジトリで利用可能。"
+description: "初期コンテキストのトークン消費量を計測する。CLAUDE.md最適化の前後比較に使用。任意のリポジトリで利用可能。サブスクリプション内で動作（追加 API 課金なし）。"
 user-invocable: true
 allowed-tools: Bash, Read, Glob, Grep
 disable-model-invocation: true
 ---
 
 初期コンテキストのトークン消費量を計測し、レポートを表示する。
+
+実測値は **現セッションの JSONL ログ** から取得する。`claude -p` を呼ばないためサブスクリプション内で完結し、追加 API 課金は発生しない。
 
 ## Step 1: 自動読み込みファイルのサイズ計測
 
@@ -29,37 +31,54 @@ if [ -d "$MEMORY_DIR" ]; then
 fi
 ```
 
-## Step 2: claude CLI でトークン実測
+## Step 2: セッション JSONL からトークン実測
 
-Bash で以下を実行し、JSON 出力から usage を抽出する：
+現セッションの最初の assistant ターンの `usage` ブロックを読み取る。`cache_creation_input_tokens` が「初期コンテキスト全体のトークン数」に相当する（cold start でフル context がキャッシュ作成されるため）。
 
 ```bash
-echo "hello" | claude -p --output-format json 2>/dev/null | python3 -c "
-import sys, json
-data = json.loads(sys.stdin.read())
-for item in data:
-    if item.get('type') == 'result':
-        u = item.get('usage', {})
-        mu = item.get('modelUsage', {})
-        print(json.dumps({
-            'total': {
-                'input_tokens': u.get('input_tokens'),
-                'cache_creation': u.get('cache_creation_input_tokens'),
-                'cache_read': u.get('cache_read_input_tokens'),
-                'output_tokens': u.get('output_tokens'),
-                'cost_usd': item.get('total_cost_usd')
-            },
-            'models': {k: {
-                'input': v.get('inputTokens'),
-                'cacheCreation': v.get('cacheCreationInputTokens'),
-                'cacheRead': v.get('cacheReadInputTokens'),
-                'output': v.get('outputTokens'),
-                'costUSD': v.get('costUSD')
-            } for k, v in mu.items()}
-        }, indent=2, ensure_ascii=False))
+PROJECT_HASH=$(pwd | sed 's|/|-|g; s|^-||')
+SESS_DIR="$HOME/.claude/projects/${PROJECT_HASH}"
+LATEST=$(ls -t "$SESS_DIR"/*.jsonl 2>/dev/null | head -1)
+if [ -z "$LATEST" ]; then
+  echo "Error: セッション JSONL が見つかりません: $SESS_DIR"
+  exit 1
+fi
+
+python3 - "$LATEST" <<'PY'
+import json, sys
+path = sys.argv[1]
+with open(path) as fp:
+    for line in fp:
+        try:
+            d = json.loads(line)
+        except Exception:
+            continue
+        if d.get('type') != 'assistant':
+            continue
+        m = d.get('message') or {}
+        u = m.get('usage')
+        if not u:
+            continue
+        cache_creation = u.get('cache_creation_input_tokens', 0)
+        cache_read = u.get('cache_read_input_tokens', 0)
+        out = {
+            'input_tokens': u.get('input_tokens', 0),
+            'cache_creation': cache_creation,
+            'cache_read': cache_read,
+            'initial_context_total': cache_creation + cache_read + u.get('input_tokens', 0),
+            'output_tokens': u.get('output_tokens', 0),
+            'model': m.get('model'),
+            'source_jsonl': path,
+        }
+        print(json.dumps(out, indent=2, ensure_ascii=False))
         break
-"
+    else:
+        print('Error: assistant ターンの usage が見つかりません', file=sys.stderr)
+        sys.exit(1)
+PY
 ```
+
+**補足**: 前後比較したい場合は、変更前後でそれぞれ新規セッションを起動し本スキルを実行してから値を比較する。同一セッション内で計測する場合は最初のターンの usage が「初期コンテキスト + 直前ユーザー入力」を含む点に留意。
 
 ## Step 3: レポート表示
 
@@ -77,14 +96,15 @@ for item in data:
 | Memory (*.md) | X | X |
 | 合計 | X | X |
 
-### トークン実測
+### トークン実測（現セッションの初回 assistant ターンから）
 | 項目 | トークン数 |
 |---|---|
 | input_tokens | X |
 | cache_creation | X |
 | cache_read | X |
 | 初期コンテキスト合計 | X |
-| コスト | $X.XX |
+| output_tokens | X |
+| model | <name> |
 ```
 
 引数に `--compare` が指定された場合:

--- a/.gitconfig
+++ b/.gitconfig
@@ -155,8 +155,10 @@
 
   tr = log --graph --pretty='format:%C(yellow)%h%Creset %s %Cgreen(%an)%Creset %Cred%d%Creset'
 
-  # commit messageの自動生成つきcommit (claude CLI使用)
-	c = "!f() { if git diff --cached --quiet; then echo 'No staged changes to commit'; else tmpfile=$(mktemp); echo 'Generating commit message with Claude...' >&2; git diff --cached | claude -p 'Analyze this git diff and generate a concise commit message following Conventional Commits format. Output only the commit message, no explanations.' > \"$tmpfile\" 2>&1; msg=$(cat \"$tmpfile\"); rm -f \"$tmpfile\"; if [ -z \"$msg\" ]; then echo 'Failed to generate commit message' >&2; return 1; fi; git commit -v -e -m \"$msg\"; fi; }; f"
+  # commit messageの自動生成つきcommit (codex CLI使用)
+  # claude -p はサブスク対象外のため codex exec に切替。
+  # codex の認証は `codex login` または OPENAI_API_KEY で事前に済ませておく。
+	c = "!f() { if git diff --cached --quiet; then echo 'No staged changes to commit'; else tmpfile=$(mktemp); echo 'Generating commit message with codex...' >&2; git diff --cached | codex exec --output-last-message \"$tmpfile\" 'Analyze this git diff and generate a concise commit message following Conventional Commits format. Output only the commit message, no explanations.' >&2; msg=$(cat \"$tmpfile\"); rm -f \"$tmpfile\"; if [ -z \"$msg\" ]; then echo 'Failed to generate commit message' >&2; return 1; fi; git commit -v -e -m \"$msg\"; fi; }; f"
 
 [filter "lfs"]
 	clean = git-lfs clean -- %f

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ update: ## Fetch changes for this repo
 .PHONY: install
 install: clean deploy ## Run make deploy, init
 
+.PHONY: patches
+patches: ## Apply claude -p replacement patches to plugin caches
+	@bash $(DOTPATH)/tools/patches/apply.sh
+
 .PHONY: backup
 backup: ## Copy target dotfiles to repository
 	@echo "Start to backup dotfiles to repository."

--- a/tools/patches/apply.sh
+++ b/tools/patches/apply.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Claude Code プラグインキャッシュ内の `claude -p` 呼び出しを書き換えるパッチ群を適用する。
+#
+# 対応方針:
+#   - improve_description.py  : codex CLI へ完全置換（テキスト生成のみで意味的に等価）
+#   - run_eval.py             : CLAUDE_ALLOW_PRINT=1 を要求する guard を挿入（claude 挙動テストが目的のため codex 置換不可）
+#   - benchmark-runner.ts     : 同じく guard を挿入
+#
+# 適用は冪等。再実行しても二重適用しない（各パッチ内で marker チェック）。
+# プラグインアップデートで上書きされたら再実行する。
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "Error: python3 が必要です" >&2
+  exit 1
+fi
+
+applied=0
+skipped=0
+missing=0
+
+apply_patch() {
+  local label="$1" script="$2"
+  shift 2
+  echo "--- $label ---"
+  if python3 "$SCRIPT_DIR/$script" "$@"; then
+    case "$?" in
+      0) applied=$((applied + 1)) ;;
+    esac
+  else
+    local rc=$?
+    case "$rc" in
+      10) skipped=$((skipped + 1)) ;;
+      20) missing=$((missing + 1)) ;;
+      *)  echo "  ERROR: rc=$rc" >&2 ;;
+    esac
+  fi
+}
+
+# skill-creator (marketplaces 配下、バージョン無しパス)
+SKILL_CREATOR_ROOT="$HOME/.claude/plugins/marketplaces/claude-plugins-official/plugins/skill-creator/skills/skill-creator/scripts"
+
+apply_patch "skill-creator/improve_description.py (codex 置換)" \
+  patch-improve-description.py \
+  "$SKILL_CREATOR_ROOT/improve_description.py"
+
+apply_patch "skill-creator/run_eval.py (env guard)" \
+  patch-run-eval.py \
+  "$SKILL_CREATOR_ROOT/run_eval.py"
+
+# vercel (cache 配下、バージョン付き)
+VERCEL_GLOB="$HOME/.claude/plugins/cache/claude-plugins-official/vercel"
+if [ -d "$VERCEL_GLOB" ]; then
+  for runner in "$VERCEL_GLOB"/*/scripts/benchmark-runner.ts; do
+    [ -e "$runner" ] || continue
+    apply_patch "vercel/$(basename "$(dirname "$(dirname "$runner")")")/benchmark-runner.ts (env guard)" \
+      patch-benchmark-runner.py \
+      "$runner"
+  done
+else
+  echo "skip: vercel プラグインキャッシュなし ($VERCEL_GLOB)"
+  missing=$((missing + 1))
+fi
+
+echo ""
+echo "=== Summary ==="
+echo "  applied: $applied"
+echo "  already patched (skipped): $skipped"
+echo "  missing target: $missing"

--- a/tools/patches/patch-benchmark-runner.py
+++ b/tools/patches/patch-benchmark-runner.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""vercel/scripts/benchmark-runner.ts に CLAUDE_ALLOW_PRINT guard を挿入する。
+
+benchmark-runner.ts は vercel-plugin の skill 注入挙動を `claude --print` で実測
+するベンチマーク。codex 置換は不可（claude 自体の挙動測定が目的）。明示的な
+opt-in を要求する guard を挿入する。
+
+exit codes:
+  0  applied
+  10 already patched
+  20 target missing
+"""
+
+import sys
+from pathlib import Path
+
+MARKER = "// PATCH:CLAUDE_PRINT_GUARD env-opt-in"
+
+ANCHOR = '  // Prevent nested session errors\n  delete env.CLAUDECODE;\n'
+
+GUARD = f'''  // Prevent nested session errors
+  delete env.CLAUDECODE;
+
+  {MARKER}
+  // claude --print はサブスク対象外（API 課金）。CLAUDE_ALLOW_PRINT=1 で明示許可が必要。
+  if (process.env.CLAUDE_ALLOW_PRINT !== "1") {{
+    throw new Error(
+      "benchmark-runner は claude --print を spawn しますが、サブスクリプション対象外で API 課金されます。" +
+      "実行するには CLAUDE_ALLOW_PRINT=1 を環境変数に設定してください。",
+    );
+  }}
+'''
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: patch-benchmark-runner.py <path>", file=sys.stderr)
+        sys.exit(2)
+
+    target = Path(sys.argv[1])
+    if not target.exists():
+        print(f"  missing: {target}")
+        sys.exit(20)
+
+    src = target.read_text()
+    if MARKER in src:
+        print(f"  already patched: {target}")
+        sys.exit(10)
+
+    if ANCHOR not in src:
+        print(f"  ERROR: anchor block not found in {target}", file=sys.stderr)
+        sys.exit(3)
+
+    new = src.replace(ANCHOR, GUARD, 1)
+    target.write_text(new)
+    print(f"  applied: {target}")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/patches/patch-improve-description.py
+++ b/tools/patches/patch-improve-description.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""skill-creator/improve_description.py の `_call_claude` を codex 呼び出しに置換する。
+
+exit codes:
+  0  applied
+  10 already patched (skipped)
+  20 target missing
+"""
+
+import re
+import sys
+from pathlib import Path
+
+MARKER = "# PATCH:CLAUDE_PRINT_GUARD codex-replacement"
+
+REPLACEMENT = '''def _call_claude(prompt: str, model: str | None, timeout: int = 300) -> str:
+    """Run codex exec (OpenAI) instead of `claude -p` and return the text response.
+
+    {marker}
+    元実装は `claude -p --output-format text` を使っていたが、Claude Code Max
+    サブスクリプションの対象外になったため codex CLI へフォールバック。codex の
+    認証 (`codex login` か OPENAI_API_KEY) は呼び出し側で済ませておく前提。
+    """
+    cmd = ["codex", "exec", "-"]
+    if model:
+        cmd.extend(["-m", model])
+
+    env = {{k: v for k, v in os.environ.items() if k != "CLAUDECODE"}}
+
+    result = subprocess.run(
+        cmd,
+        input=prompt,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"codex exec exited {{result.returncode}}\\nstderr: {{result.stderr}}"
+        )
+    return result.stdout
+'''.format(marker=MARKER)
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: patch-improve-description.py <path>", file=sys.stderr)
+        sys.exit(2)
+
+    target = Path(sys.argv[1])
+    if not target.exists():
+        print(f"  missing: {target}")
+        sys.exit(20)
+
+    src = target.read_text()
+    if MARKER in src:
+        print(f"  already patched: {target}")
+        sys.exit(10)
+
+    pattern = re.compile(
+        r'def _call_claude\(prompt: str, model: str \| None, timeout: int = 300\) -> str:\n'
+        r'(?:[^\n]*\n)+?'
+        r'    return result\.stdout\n',
+        re.MULTILINE,
+    )
+    if not pattern.search(src):
+        print(f"  ERROR: _call_claude のシグネチャが想定と異なる: {target}", file=sys.stderr)
+        sys.exit(3)
+
+    # Use a lambda so re.sub doesn't interpret \n / \1 etc inside the replacement.
+    new = pattern.sub(lambda _m: REPLACEMENT, src, count=1)
+    target.write_text(new)
+    print(f"  applied: {target}")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/patches/patch-run-eval.py
+++ b/tools/patches/patch-run-eval.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""skill-creator/run_eval.py に CLAUDE_ALLOW_PRINT guard を挿入する。
+
+run_eval.py は claude が skill description で正しくトリガーするかを評価するため
+`claude -p` を spawn する。codex に置換すると別 LLM の挙動を測ることになり意味的
+に成立しないので、明示的な opt-in (CLAUDE_ALLOW_PRINT=1) を要求する guard を入
+れる。
+
+exit codes:
+  0  applied
+  10 already patched
+  20 target missing
+"""
+
+import sys
+from pathlib import Path
+
+MARKER = "# PATCH:CLAUDE_PRINT_GUARD env-opt-in"
+
+ANCHOR = '''        cmd = [
+            "claude",
+            "-p", query,
+            "--output-format", "stream-json",
+            "--verbose",
+            "--include-partial-messages",
+        ]'''
+
+GUARD = f'''        # {MARKER}
+        # claude -p はサブスク対象外（API 課金）。CLAUDE_ALLOW_PRINT=1 で明示許可した場合のみ実行。
+        if os.environ.get("CLAUDE_ALLOW_PRINT") != "1":
+            raise RuntimeError(
+                "run_eval.py は claude -p を spawn しますが、サブスクリプション対象外で API 課金されます。"
+                "実行するには CLAUDE_ALLOW_PRINT=1 を環境変数に設定してください。"
+            )
+'''
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("usage: patch-run-eval.py <path>", file=sys.stderr)
+        sys.exit(2)
+
+    target = Path(sys.argv[1])
+    if not target.exists():
+        print(f"  missing: {target}")
+        sys.exit(20)
+
+    src = target.read_text()
+    if MARKER in src:
+        print(f"  already patched: {target}")
+        sys.exit(10)
+
+    if ANCHOR not in src:
+        print(f"  ERROR: anchor block not found in {target}", file=sys.stderr)
+        sys.exit(3)
+
+    new = src.replace(ANCHOR, GUARD + ANCHOR, 1)
+    target.write_text(new)
+    print(f"  applied: {target}")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Claude Code Max サブスクリプションが `claude -p` / `claude --print` を対象外とし API クレジット個別課金になる方針に対応。dotfiles 全体で意図しない API 課金を防ぐためのガード・代替手段・プラグインパッチ運用を整備した。

## Changes

- **`.claude/hooks/guard.sh`**: Bash ツール経由の `claude -p` / `--print` を BLOCK するルール追加。`CLAUDE_ALLOW_PRINT=1` で明示 opt-in 可
- **`.claude/CLAUDE.md`**: `claude -p` 代替方針セクション追加（Skill 内は agent、外部 script は codex CLI、測定用途のみ opt-in）
- **`tools/patches/apply.sh`**: 外部プラグイン (skill-creator / vercel) キャッシュ配下の `claude -p` 呼び出しを書き換える冪等パッチランナー
- **`tools/patches/patch-*.py`**: 3 種のパッチ実装（benchmark-runner / improve-description / run-eval）
- **`Makefile`**: `make patches` ターゲットを追加
- **`.claude/skills/measure-context.md`**: 関連 skill のドキュメント更新
- **`.gitconfig`**: 微調整

## Files Changed

- Added: 4 files (`tools/patches/apply.sh`, `patch-benchmark-runner.py`, `patch-improve-description.py`, `patch-run-eval.py`)
- Modified: 5 files (`.claude/CLAUDE.md`, `.claude/hooks/guard.sh`, `.claude/skills/measure-context.md`, `.gitconfig`, `Makefile`)

## Testing

- [ ] `claude -p "hello"` を実行して BLOCK されることを確認
- [ ] `CLAUDE_ALLOW_PRINT=1 claude -p "hello"` で WARN ログ出力かつ通過することを確認
- [ ] `make patches` の冪等性確認（2 回実行しても二重適用されない）
- [ ] BLOCK ログが `~/.claude/logs/guard-YYYY-MM-DD.jsonl` に出ることを確認

## Notes

- codex CLI 認証 (`codex login` または `OPENAI_API_KEY`) が前提
- 対話モード (`--dangerously-skip-permissions` や cmux-agent 経由) はサブスク対象内のため影響なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guard mechanism to control command execution with opt-in environment flag support and logging.
  * Introduced patching system to update cached plugin files.

* **Documentation**
  * Updated billing and subscription guidance documentation.
  * Enhanced token measurement skill with updated measurement methodology and subscription cost clarification.

* **Changes**
  * Modified commit message auto-generation workflow with updated authentication requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/valbeat/dotfiles/pull/76)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->