### PR TITLE
chore(coderabbit): add repository review configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,66 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# https://docs.coderabbit.ai/reference/configuration
+
+language: en-US
+tone_instructions: "Be concise. Prefer concrete file/line suggestions over abstract advice."
+early_access: false
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+  path_filters:
+    - "!.claude/projects/**"
+    - "!.claude/cache/**"
+    - "!.claude/logs/**"
+    - "!.claude/file-history/**"
+    - "!.claude/history.jsonl"
+    - "!.claude/sessions/**"
+    - "!.claude/statsig/**"
+    - "!.claude/todos/**"
+    - "!.claude/shell-snapshots/**"
+    - "!.codex/.tmp/**"
+    - "!.vim/dein/**"
+    - "!.vim/undo/**"
+    - "!.vim/bookmark/**"
+  path_instructions:
+    - path: "**/*.sh"
+      instructions: "POSIX/bash 互換性、`set -euo pipefail` の有無、quoting、ShellCheck 警告を確認する。"
+    - path: ".zshrc"
+      instructions: "PATH/fpath の重複や順序、対話シェル限定の処理が `[[ -o interactive ]]` などで保護されているかを確認する。"
+    - path: ".claude/hooks/*.sh"
+      instructions: "Claude Code hook の終了コード規約 (0=allow, 2=deny) と stdin から渡される JSON の扱いを確認する。"
+    - path: "tools/patches/**"
+      instructions: "冪等性 (再実行で二重適用されない marker チェック) とロールバック手段の有無を確認する。"
+    - path: "**/CLAUDE.md"
+      instructions: "ルールが具体的で、ファイル参照や手順が現存するか軽くチェックする。長文化を避ける指摘を優先する。"
+
+tools:
+  shellcheck:
+    enabled: true
+  markdownlint:
+    enabled: true
+  yamllint:
+    enabled: true
+  actionlint:
+    enabled: true
+  gitleaks:
+    enabled: true
+
+knowledge_base:
+  opt_out: false
+  learnings:
+    scope: auto
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "**/CLAUDE.md"
+      - "AGENTS.md"


### PR DESCRIPTION
## Summary
- Add `.coderabbit.yaml` to ground CodeRabbit reviews on this repo's actual surface (shell/zsh, Claude/Codex/Vim configs, hook & patch tooling).
- Filter out generated caches (`.claude/{projects,cache,logs,...}`, `.codex/.tmp/**`, `.vim/{undo,dein,bookmark}/**`) to keep diffs signal-only.
- Enable `shellcheck` / `markdownlint` / `yamllint` / `actionlint` / `gitleaks`, and wire `knowledge_base.code_guidelines` to existing `CLAUDE.md` and `AGENTS.md`.

## Test plan
- [x] `coderabbit --version` → `0.5.0`
- [x] `coderabbit auth status --agent` → authenticated
- [x] `coderabbit review --agent --type uncommitted` → completed with 0 findings on the yaml itself
- [ ] CodeRabbit bot picks up the config on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CodeRabbit configuration to standardize code reviews and enable automated quality checks, including linting and security scanning tools for improved project maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/valbeat/dotfiles/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->