### PR TITLE
feat: add Brewfile for declarative package management

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,492 @@
+tap "appsody/appsody"
+tap "arto-app/tap"
+tap "brona/iproute2mac"
+tap "bufbuild/buf"
+tap "c-bata/kube-prompt"
+tap "datawire/blackbird"
+tap "derailed/k9s"
+tap "derailed/popeye"
+tap "dotenvx/brew"
+tap "dtan4/tools"
+tap "ethereum/ethereum"
+tap "garethr/kubeval"
+tap "getsentry/tools"
+tap "go-delve/delve"
+tap "hashicorp/tap"
+tap "icu4c/taps"
+tap "jesseduffield/lazydocker"
+tap "johanhaleby/kubetail"
+tap "ktr0731/evans"
+tap "kyoshidajp/ghkw"
+tap "laurent22/massren"
+tap "osx-cross/avr"
+tap "px4/px4"
+tap "rcmdnk/rcmdnkpac"
+tap "reviewdog/tap"
+tap "rinchsan/tap"
+tap "sachaos/todoist"
+tap "sanemat/font"
+tap "stripe/stripe-cli"
+tap "supabase/tap"
+tap "tldr-pages/tldr"
+tap "wagoodman/dive"
+tap "yakitrak/yakitrak"
+# All-in-one AI-Powered CLI Chat & Copilot
+brew "aichat"
+# Access Log Profiler
+brew "alp"
+# All in one for **env
+brew "anyenv"
+# Cryptography and SSL/TLS Toolkit
+brew "openssl@3"
+# Library for manipulating PNG images
+brew "libpng"
+# Automatic configure script builder
+brew "autoconf"
+# Tool for generating GNU Standards-compliant Makefiles
+brew "automake"
+# Bourne-Again SHell, a UNIX command interpreter
+brew "bash"
+# Programmable completion for Bash 3.2
+brew "bash-completion"
+# Regular expressions library
+brew "oniguruma"
+# Clone of cat(1) with syntax highlighting and Git integration
+brew "bat"
+# General-purpose data compression with high compression ratio
+brew "xz"
+# GNU binary tools for native development
+brew "binutils"
+# Parser generator
+brew "bison"
+# Freely available high-quality data compressor
+brew "bzip2"
+# Core application library for C
+brew "glib"
+# Share macOS clipboard with tmux and other local and remote apps
+brew "clipper"
+# Cross-platform make
+brew "cmake"
+# Color-highlighted diff(1) output
+brew "colordiff"
+# Get a file from an HTTP, HTTPS or FTP server
+brew "curl"
+# Generic library support script
+brew "libtool"
+# Image format providing lossless and lossy compression for web images
+brew "webp"
+# Graphics library to dynamically manipulate images
+brew "gd"
+# Network authentication protocol
+brew "krb5"
+# C library for reading, creating, and modifying zip archives
+brew "libzip"
+# Granddaddy of HTML tools, with support for modern standards
+brew "tidy-html5"
+# General-purpose scripting language
+brew "php"
+# Dependency Manager for PHP
+brew "composer"
+# GNU File, Shell, and Text utilities
+brew "coreutils"
+# Tool for browsing source code
+brew "cscope"
+# Reimplementation of ctags(1)
+brew "ctags"
+# Top-like interface for container metrics
+brew "ctop"
+# High-level C binding for ZeroMQ
+brew "czmq"
+# Modern diagram scripting language that turns text to diagrams
+brew "d2"
+# Secure runtime for JavaScript and TypeScript
+brew "deno"
+# Kubernetes command-line interface
+brew "kubernetes-cli"
+# CLI helps develop/deploy/debug apps with Docker and k8s
+brew "devspace"
+# Device firmware update based USB programmer for Atmel chips
+brew "dfu-programmer"
+# Good-lookin' diffs with diff-highlight and more
+brew "diff-so-fancy"
+# Load/unload environment variables based on $PWD
+brew "direnv"
+# Tool for exploring each layer in a docker image
+brew "dive"
+# Lightweight DNS forwarder and DHCP server
+brew "dnsmasq", restart_service: :changed
+# Docker Credential Helper for Amazon ECR
+brew "docker-credential-helper-ecr"
+# Emoji on the command-line :scream:
+brew "emojify"
+# Cross-platform C++ GUI toolkit
+brew "wxwidgets"
+# Programming language for highly scalable real-time systems
+brew "erlang"
+# Modern replacement for 'ls'
+brew "exa"
+# Simple, fast and user-friendly alternative to find
+brew "fd"
+# Play, record, convert, and stream select audio and video codecs
+brew "ffmpeg"
+# Collection of GNU find, xargs, and locate
+brew "findutils"
+# C/C++ and Java libraries for Unicode and globalization
+brew "icu4c@76"
+# Command-line outline and bitmap font editor/converter
+brew "fontforge"
+# Terminal JSON viewer
+brew "fx"
+# Command-line fuzzy finder written in Go
+brew "fzf"
+# Easily access your Google Calendar(s) from a command-line
+brew "gcalcli"
+# GNU compiler collection
+brew "gcc"
+# Toolkit for image loading and pixel buffer manipulation
+brew "gdk-pixbuf"
+# GitHub command-line tool
+brew "gh"
+# Interpreter for PostScript and PDF
+brew "ghostscript"
+# Remote repository management made easy
+brew "ghq"
+# Access GitHub's .gitignore boilerplates
+brew "gibo"
+# Distributed revision control system
+brew "git"
+# Extensions to follow Vincent Driessen's branching model
+brew "git-flow"
+# Git extension for versioning large files
+brew "git-lfs"
+# Command-line option parsing utility
+brew "gnu-getopt"
+# Light, temporary commits for git
+brew "git-now"
+# Prevents you from committing sensitive information to a git repo
+brew "git-secrets"
+# OpenGL and OpenGL ES reference compiler for shading languages
+brew "glslang"
+# Asynchronous event library
+brew "libevent"
+# GNU Transport Layer Security (TLS) Library
+brew "gnutls"
+# Open source programming language to build simple/reliable/efficient software
+brew "go"
+# Task is a task runner/build tool that aims to be simpler and easier to use
+brew "go-task"
+# Package compiler and linker metadata toolkit
+brew "pkgconf"
+# Generate introspection data for GObject libraries
+brew "gobject-introspection"
+# Database migrations CLI tool
+brew "golang-migrate"
+# Library for manipulating JPEG-2000 images
+brew "jasper"
+# Image manipulation
+brew "netpbm"
+# Library to render SVG files using Cairo
+brew "librsvg"
+# Graph visualization software from AT&T and Bell Labs
+brew "graphviz"
+# GNU troff text-formatting system
+brew "groff"
+# Java-based scripting language
+brew "groovy"
+# Like cURL, but for gRPC
+brew "grpcurl"
+# GNU Ubiquitous Intelligent Language for Extensions
+brew "guile"
+# Smarter Dockerfile linter to validate best practices
+brew "hadolint"
+# Kubernetes package manager
+brew "helm"
+# Deploy Kubernetes Helm Charts
+brew "helmfile"
+# Convert source code to formatted text with syntax highlighting
+brew "highlight"
+# Improved top (interactive process viewer)
+brew "htop"
+# Add GitHub support to git on the command-line
+brew "hub"
+# Configurable static site generator
+brew "hugo"
+# ISO/IEC 23008-12:2017 HEIF file format decoder and encoder
+brew "libheif"
+# Tools and libraries to manipulate images in select formats
+brew "imagemagick"
+# Tools and libraries to manipulate images in many formats
+brew "imagemagick@6"
+# CLI wrapper for basic network utilities on macOS - ip command
+brew "iproute2mac"
+# JSON output from a shell
+brew "jo"
+# Image manipulation library
+brew "jpeg"
+# Lightweight and flexible command-line JSON processor
+brew "jq"
+# Tool to move from `docker-compose` to Kubernetes
+brew "kompose"
+# Tool that can switch between kubectl contexts easily and create aliases
+brew "kubectx"
+# Validate Kubernetes configuration files, supports multiple Kubernetes versions
+brew "kubeval"
+# BSD-style licensed readline alternative
+brew "libedit"
+# Conversion library
+brew "libiconv"
+# Rainbows and unicorns in your console!
+brew "lolcat"
+# Keep your Mac's application settings in sync
+brew "mackup"
+# GUI for vim, made for macOS
+brew "macvim"
+# Utility for directing compilation
+brew "make"
+# Easily convert Marp Markdown files into static HTML/CSS, PDF, PPT and images
+brew "marp-cli"
+# Run a Kubernetes cluster locally
+brew "minikube"
+# Simple tool to make locally trusted development certificates
+brew "mkcert"
+# Protocol buffers (Google's data interchange format)
+brew "protobuf"
+# Remote terminal application
+brew "mosh"
+# Tail multiple files in one terminal simultaneously
+brew "multitail"
+# CLI for MySQL with auto-completion and syntax highlighting
+brew "mycli"
+# General-purpose lossless data-compression library
+brew "zlib"
+# Open source relational database management system
+brew "mysql"
+# Search tool like grep and The Silver Searcher
+brew "ripgrep"
+# Text interface for Git repositories
+brew "tig"
+# Command-line and local web note-taking, bookmarking, and archiving
+brew "nb"
+# HTTP/2 C Library
+brew "nghttp2"
+# C library to read whole-slide images (a.k.a. virtual slides)
+brew "openslide"
+# Cryptography and SSL/TLS Toolkit
+brew "openssl@1.1"
+# Small collection of programs that operate on patch files
+brew "patchutils"
+# Simplistic interactive filtering tool
+brew "peco"
+# Draw UML diagrams
+brew "plantuml"
+# PDF rendering library (based on the xpdf-3.0 code base)
+brew "poppler"
+# Show ps output as a tree
+brew "pstree"
+# Python version management
+brew "pyenv"
+# Pyenv plugin to manage virtualenv
+brew "pyenv-virtualenv"
+# Interpreted, interactive, object-oriented programming language
+brew "python@3.12"
+# Tiny command-line DNS client with support for UDP, TCP, DoT, DoH, DoQ and ODoH
+brew "q"
+# QR Code generation
+brew "qrencode"
+# Cross-platform application and UI framework
+brew "qt"
+# Software environment for statistical computing
+brew "r"
+# Generate C-based recognizers from regular expressions
+brew "re2c"
+# Reattach process (e.g., tmux) to background
+brew "reattach-to-user-namespace"
+# Perl-powered file rename script with many helpful built-ins
+brew "rename"
+# Safe, concurrent, practical language
+brew "rust"
+# 7-Zip is a file archiver with a high compression ratio
+brew "sevenzip"
+# Static analysis and lint tool, for (ba)sh scripts
+brew "shellcheck"
+# Autoformat shell script source code
+brew "shfmt"
+# Easy and Repeatable Kubernetes Development
+brew "skaffold"
+# Editor of encrypted files
+brew "sops"
+# Secure Reliable Transport
+brew "srt"
+# Tail multiple Kubernetes pods & their containers
+brew "stern"
+# Command-line integration for Teensy USB development boards
+brew "teensy_loader_cli"
+# User interface to the TELNET protocol
+brew "telnet"
+# Send macOS User Notifications from the command-line
+brew "terminal-notifier"
+# Terraform version manager inspired by rbenv
+brew "tfenv"
+# Code-search similar to ack
+brew "the_silver_searcher"
+# Simplified and community-driven man pages
+brew "tldr"
+# Terminal multiplexer
+brew "tmux"
+# Command-line translator using Google Translate and more
+brew "translate-shell"
+# CLI tool that moves files or folder to the trash
+brew "trash", link: true
+# Display directories as trees (with optional color/HTML output)
+brew "tree"
+# Command-line unarchiving tools supporting multiple formats
+brew "unar"
+# Extremely fast Python package installer and resolver, written in Rust
+brew "uv"
+# HTTP load testing tool and library
+brew "vegeta"
+# Command-line interface for Vercel
+brew "vercel-cli"
+# Image processing library
+brew "vips"
+# Executes a program periodically, showing output fullscreen
+brew "watch"
+# Internet file retriever
+brew "wget"
+# Network settings helper
+brew "whatmask"
+# Blazing fast terminal file manager written in Rust, based on async I/O
+brew "yazi"
+# Feature-rich command-line audio/video downloader
+brew "yt-dlp"
+# Shell extension to navigate your filesystem faster
+brew "zoxide"
+# Next-generation plugin manager for zsh
+brew "zplug"
+# UNIX shell (command interpreter)
+brew "zsh"
+# Additional completion definitions for zsh
+brew "zsh-completions"
+# The Art of Reading Markdown.
+cask "arto-app/tap/arto"
+# Securely stores and accesses AWS credentials in a development environment
+cask "aws-vault-binary"
+# Audio utility
+cask "background-music-pre"
+# Virtual Audio Driver
+cask "blackhole-16ch"
+# Free and open-source web browser
+cask "chromium"
+# Ghostty-based terminal with vertical tabs and notifications for AI coding agents
+cask "cmux"
+cask "font-symbols-only-nerd-font"
+# Set of tools to manage resources and applications hosted on Google Cloud
+cask "gcloud-cli"
+# Terminal built on web technologies
+cask "hyper"
+# Adaptive brightness for external displays
+cask "lunar"
+# Markdown editor
+cask "markedit"
+# Neovim Client
+cask "neovide-app"
+# Replacement for Docker Desktop
+cask "orbstack"
+vscode "3w36zj6.textlint"
+vscode "8amjp.charactercount"
+vscode "ahmadalli.vscode-nginx-conf"
+vscode "anthropic.claude-code"
+vscode "bierner.markdown-mermaid"
+vscode "biomejs.biome"
+vscode "bmewburn.vscode-intelephense-client"
+vscode "bradlc.vscode-tailwindcss"
+vscode "castwide.solargraph"
+vscode "cweijan.dbclient-jdbc"
+vscode "cweijan.vscode-database-client2"
+vscode "dbaeumer.vscode-eslint"
+vscode "eamodio.gitlens"
+vscode "ecmel.vscode-html-css"
+vscode "editorconfig.editorconfig"
+vscode "fallenmax.mithril-emmet"
+vscode "foam.foam-vscode"
+vscode "gera2ld.markmap-vscode"
+vscode "github.vscode-github-actions"
+vscode "goessner.mdmath"
+vscode "golang.go"
+vscode "hediet.vscode-drawio"
+vscode "ipedrazas.kubernetes-snippets"
+vscode "jakebathman.mysql-syntax"
+vscode "jebbs.plantuml"
+vscode "k--kato.docomment"
+vscode "k--kato.intellij-idea-keybindings"
+vscode "marp-team.marp-vscode"
+vscode "mermaidchart.vscode-mermaid-chart"
+vscode "mrcrowl.hg"
+vscode "mrmlnc.vscode-apache"
+vscode "ms-azuretools.vscode-containers"
+vscode "ms-ceintl.vscode-language-pack-ja"
+vscode "ms-dotnettools.csdevkit"
+vscode "ms-dotnettools.csharp"
+vscode "ms-dotnettools.vscode-dotnet-runtime"
+vscode "ms-kubernetes-tools.vscode-kubernetes-tools"
+vscode "ms-python.debugpy"
+vscode "ms-python.isort"
+vscode "ms-python.python"
+vscode "ms-python.vscode-pylance"
+vscode "ms-python.vscode-python-envs"
+vscode "ms-toolsai.jupyter"
+vscode "ms-toolsai.jupyter-keymap"
+vscode "ms-toolsai.jupyter-renderers"
+vscode "ms-toolsai.vscode-jupyter-cell-tags"
+vscode "ms-toolsai.vscode-jupyter-slideshow"
+vscode "ms-vscode-remote.remote-containers"
+vscode "ms-vscode.copilot-mermaid-diagram"
+vscode "ms-vscode.makefile-tools"
+vscode "ms-vscode.mono-debug"
+vscode "ms-vscode.vscode-speech"
+vscode "ms-vscode.wordcount"
+vscode "msysyamamoto.vscode-fluentd"
+vscode "openai.chatgpt"
+vscode "pkief.material-icon-theme"
+vscode "raynigon.nginx-formatter"
+vscode "redhat.vscode-yaml"
+vscode "rooveterinaryinc.roo-cline"
+vscode "rust-lang.rust-analyzer"
+vscode "ryu1kn.annotator"
+vscode "shanoor.vscode-nginx"
+vscode "shd101wyy.markdown-preview-enhanced"
+vscode "shopify.ruby-lsp"
+vscode "slevesque.shader"
+vscode "styled-components.vscode-styled-components"
+vscode "teabyii.ayu"
+vscode "technosophos.vscode-helm"
+vscode "techtrain.railway-vscode"
+vscode "tekumara.typos-vscode"
+vscode "toba.vsfire"
+vscode "tomoki1207.pdf"
+vscode "victoriadrake.kabukicho"
+vscode "vscodevim.vim"
+vscode "xyz.plsql-language"
+vscode "zhuangtongfa.material-theme"
+go "github.com/GoogleCloudPlatform/cloudsql-proxy/cmd/cloud_sql_proxy"
+go "github.com/daixiang0/gci"
+go "github.com/ramya-rao-a/go-outline"
+go "golang.org/dl/go1.22.3"
+go "github.com/stamblerre/gocode"
+go "github.com/rogpeppe/godef"
+go "golang.org/x/tools/cmd/goimports"
+go "github.com/fatih/gomodifytags"
+go "github.com/haya14busa/goplay/cmd/goplay"
+go "golang.org/x/tools/gopls"
+go "github.com/cweill/gotests/gotests"
+go "github.com/d-kuro/gwq/cmd/gwq"
+go "github.com/josharian/impl"
+go "github.com/mattn/memo"
+go "github.com/golang/mock/mockgen"
+go "go.ngrok.com/cmd/ngrok"
+go "github.com/google/skicka"
+go "github.com/cloudspannerecosystem/spanner-cli"
+go "honnef.co/go/tools/cmd/staticcheck"
+go "github.com/valbeat/whatday"
+npm "@openai/codex"
+npm "corepack"

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,18 @@ update: ## Fetch changes for this repo
 .PHONY: install
 install: clean deploy ## Run make deploy, init
 
+.PHONY: brew
+brew: ## Install packages from Brewfile
+	@echo "Start to install packages from Brewfile."
+	@echo ""
+	@brew bundle --file=$(DOTPATH)/Brewfile
+
+.PHONY: brew-dump
+brew-dump: ## Update Brewfile from current environment
+	@echo "Start to dump Brewfile from current environment."
+	@echo ""
+	@brew bundle dump --force --file=$(DOTPATH)/Brewfile
+
 .PHONY: patches
 patches: ## Apply claude -p replacement patches to plugin caches
 	@bash $(DOTPATH)/tools/patches/apply.sh

--- a/README.md
+++ b/README.md
@@ -9,6 +9,20 @@ $ make install
 ```
 This will create symlinks from this repo to your home folder.
 
+## Homebrew packages
+
+Install the packages declared in the `Brewfile`:
+
+```shell
+$ make brew
+```
+
+After installing or removing packages, refresh the `Brewfile`:
+
+```shell
+$ make brew-dump
+```
+
 ## Contribution
 
 1. Fork ([https://github.com/valbeat/dotfiles/fork](https://github.com/valbeat/dotfiles/fork))


### PR DESCRIPTION
## 概要

このリポジトリに欠けていた**パッケージ管理**を Homebrew の `Brewfile` で補う。dotfiles（シンボリックリンク）+ Brewfile で、新マシンの環境を再現可能にする。

## 変更内容

- `Brewfile` を追加（`brew bundle dump` で現環境をスナップショット）
  - tap / formula / cask / VS Code拡張 / go / npm を宣言
  - 冗長な内蔵tap（`homebrew/core`, `cask`, `bundle` 等）と廃止済みの `homebrew/cask-versions` は除外
- `Makefile` に `brew`（インストール）/ `brew-dump`（更新）ターゲットを追加
- `README.md` に手順を追記

## 公開リポジトリ観点のレビュー

- 認証情報・メール・トークンの混入なし
- `mas`（App Store / Apple ID 紐付け）は0件
- 個人リポジトリ参照は `valbeat/whatday`（自身の公開リポジトリ）のみ

## 確認

- `brew bundle list --file=./Brewfile` が exit 0（構文エラーなし）

## 補足（任意の追従候補）

- 古いバージョン固定: `golang.org/dl/go1.22.3`, `openssl@1.1`(EOL), `imagemagick@6`

https://claude.ai/code/session_017q6Xu2uuGNLmsQWNe5Jwwq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Homebrew package management configuration with support for pre-configured macOS packages, tools, and applications
  * New commands available to install packages and update configuration after local changes

* **Documentation**
  * Added documentation explaining the Homebrew package management setup and available workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->