### PR TITLE
chore: address Brewfile review comments and prune global packages

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -123,8 +123,6 @@ brew "emojify"
 brew "wxwidgets"
 # Programming language for highly scalable real-time systems
 brew "erlang"
-# Modern replacement for 'ls'
-brew "exa"
 # Simple, fast and user-friendly alternative to find
 brew "fd"
 # Play, record, convert, and stream select audio and video codecs
@@ -215,8 +213,6 @@ brew "hugo"
 brew "libheif"
 # Tools and libraries to manipulate images in select formats
 brew "imagemagick"
-# Tools and libraries to manipulate images in many formats
-brew "imagemagick@6"
 # CLI wrapper for basic network utilities on macOS - ip command
 brew "iproute2mac"
 # JSON output from a shell
@@ -271,8 +267,6 @@ brew "nb"
 brew "nghttp2"
 # C library to read whole-slide images (a.k.a. virtual slides)
 brew "openslide"
-# Cryptography and SSL/TLS Toolkit
-brew "openssl@1.1"
 # Small collection of programs that operate on patch files
 brew "patchutils"
 # Simplistic interactive filtering tool
@@ -287,8 +281,6 @@ brew "pstree"
 brew "pyenv"
 # Pyenv plugin to manage virtualenv
 brew "pyenv-virtualenv"
-# Interpreted, interactive, object-oriented programming language
-brew "python@3.12"
 # Tiny command-line DNS client with support for UDP, TCP, DoT, DoH, DoQ and ODoH
 brew "q"
 # QR Code generation
@@ -471,7 +463,6 @@ vscode "zhuangtongfa.material-theme"
 go "github.com/GoogleCloudPlatform/cloudsql-proxy/cmd/cloud_sql_proxy"
 go "github.com/daixiang0/gci"
 go "github.com/ramya-rao-a/go-outline"
-go "golang.org/dl/go1.22.3"
 go "github.com/stamblerre/gocode"
 go "github.com/rogpeppe/godef"
 go "golang.org/x/tools/cmd/goimports"

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,12 @@ brew-dump: ## Update Brewfile from current environment
 	@echo "Start to dump Brewfile from current environment."
 	@echo ""
 	@brew bundle dump --force --file=$(DOTPATH)/Brewfile
+	@# Drop redundant built-in taps that brew bundle re-adds on every dump.
+	@sed -i '' -E '/^tap "homebrew\/(brewdler|bundle|cask|cask-versions|core|services)"$$/d' $(DOTPATH)/Brewfile
+	@echo ""
+	@echo "Brewfile regenerated. Review 'git diff Brewfile' before committing:"
+	@echo "  - EOL/deprecated packages (e.g. openssl@1.1, imagemagick@6) may reappear."
+	@echo "  - run 'brew uninstall' to remove them from the system, not just this file."
 
 .PHONY: patches
 patches: ## Apply claude -p replacement patches to plugin caches

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ After installing or removing packages, refresh the `Brewfile`:
 $ make brew-dump
 ```
 
+`brew-dump` regenerates the whole `Brewfile` from the current environment.
+Redundant built-in taps are stripped automatically, but EOL/deprecated
+packages reappear if they are still installed. Review `git diff Brewfile`
+after running it, and use `brew uninstall` to remove unwanted packages from
+the system rather than only deleting their lines here.
+
 ## Contribution
 
 1. Fork ([https://github.com/valbeat/dotfiles/fork](https://github.com/valbeat/dotfiles/fork))


### PR DESCRIPTION
PR #78 のレビューコメント対応と、global に入れるべきでないパッケージの精査結果。

## レビューコメント対応（Gemini）

- **`openssl@1.1` を削除** — deprecated/EOL（2023-09 サポート終了）。`openssl@3` が既に存在
- **`brew-dump` の上書き問題に対応** — ダンプ後に冗長な内蔵tap（`homebrew/core` 等）を `sed` で自動除外し、diff確認を促す warning を出力。手動クリーンアップが次回dumpで消えないように
- **README に再生成時の注意を追記** — EOLパッケージは installed のままだと再出現する旨、`brew uninstall` での除去を案内

## global に入れるべきでないものの精査

依存元なし（leaf）で安全に削除できるものを除外：

| パッケージ | 理由 |
|---|---|
| `imagemagick@6` | EOL（deprecated）。v7 が既にある |
| `python@3.12` | pyenv で管理。brew版は二重管理 |
| `golang.org/dl/go1.22.3` | 陳腐化したtoolchainピン（システム go は 1.24.3） |
| `exa` | upstream アーカイブ済み。後継 eza へ |

### 残した判断
- `hub` — deprecated だが `.zshrc:890` で `hub browse` を実使用中のため残置
- `pyenv` / `pyenv-virtualenv` — anyenv 経由でなく brew が実体のため残置

## 確認
- `brew bundle list --file=./Brewfile` が exit 0

## 補足（このPR対象外）
- CodeRabbit が `.coderabbit.yaml` の `tools` キーを未認識と警告。別途整理候補

https://claude.ai/code/session_017q6Xu2uuGNLmsQWNe5Jwwq