### PR TITLE
chore: decouple from deprecated tools and migrate exa to eza

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -887,7 +887,7 @@ function fzf-src-remote () {
 
   if [[ "${selected}" =~ ^github.com.*  ]]; then
     local repo=$(echo ${selected} | rev | cut -d "/" -f -2 | rev)
-    BUFFER="hub browse ${repo}"
+    BUFFER="gh browse -R ${repo}"
     zle accept-line
   fi
   # for others

--- a/Brewfile
+++ b/Brewfile
@@ -123,6 +123,8 @@ brew "emojify"
 brew "wxwidgets"
 # Programming language for highly scalable real-time systems
 brew "erlang"
+# Modern, maintained replacement for ls (successor to exa)
+brew "eza"
 # Simple, fast and user-friendly alternative to find
 brew "fd"
 # Play, record, convert, and stream select audio and video codecs
@@ -205,8 +207,6 @@ brew "helmfile"
 brew "highlight"
 # Improved top (interactive process viewer)
 brew "htop"
-# Add GitHub support to git on the command-line
-brew "hub"
 # Configurable static site generator
 brew "hugo"
 # ISO/IEC 23008-12:2017 HEIF file format decoder and encoder


### PR DESCRIPTION
PR #79 で「残す判断」とした非推奨ツールを、適切に依存しないよう移行して切り離す。

> 補足: 本変更は一度誤って main へ直接コミット（ef7df4a）してしまったため、main 側で revert（2f43f1d）した上で本PRに再適用しています。

## 変更内容

- **hub → gh** — `.zshrc` の `hub browse` を `gh browse -R` に置換し、`hub`（deprecated）への依存を解消。Brewfileから `hub` を削除
- **exa → eza** — exa は upstream アーカイブ済み。後継 `eza` をBrewfileに追加（exaは前PRで削除済み）

## 残置の判断
- **openssl@1.1** — formula `q` が依存するため uninstall せず残置（Brewfileには非掲載。`brew bundle` が `q` 経由で自動取得）

## 適用済みのシステム変更
- `brew uninstall hub exa imagemagick@6 python@3.12`
- `brew install eza`（+ `brew reinstall libgit2` で llhttp リンク不整合を解消し dyld エラーを修正）
- 陳腐化した go1.22.3 toolchain を削除（`~/bin/go1.22.3`, `~/sdk/go1.22.3`）

## 確認
- `brew bundle list --file=./Brewfile` exit 0
- `eza --version` → v0.23.4
- `gh browse -R OWNER/REPO` が有効

https://claude.ai/code/session_017q6Xu2uuGNLmsQWNe5Jwwq