### PR TITLE
feat(nix-darwin): Phase 1 - migrate .osx to system.defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,28 @@ packages reappear if they are still installed. Review `git diff Brewfile`
 after running it, and use `brew uninstall` to remove unwanted packages from
 the system rather than only deleting their lines here.
 
+## nix-darwin (experimental, Phase 1)
+
+macOS system settings are being migrated from the imperative `.osx` script to
+declarative [nix-darwin](https://github.com/nix-darwin/nix-darwin). Phase 1
+covers `system.defaults` only; see [docs/nix-darwin-design.md](docs/nix-darwin-design.md)
+for the full plan. `.osx` is kept until the migration is verified.
+
+Prerequisites: install Nix (flakes enabled), e.g. the Determinate Systems installer:
+
+```shell
+$ /bin/sh -c "$(curl --proto '=https' --tlsv1.2 -sSfL https://install.determinate.systems/nix)" -- install
+```
+
+Bootstrap once, then rebuild on changes:
+
+```shell
+$ nix run nix-darwin -- switch --flake ~/dotfiles#takumas-MacBook-Pro
+$ darwin-rebuild switch --flake ~/dotfiles#takumas-MacBook-Pro
+```
+
+Roll back with `darwin-rebuild --rollback`.
+
 ## Contribution
 
 1. Fork ([https://github.com/valbeat/dotfiles/fork](https://github.com/valbeat/dotfiles/fork))

--- a/darwin/configuration.nix
+++ b/darwin/configuration.nix
@@ -1,0 +1,24 @@
+{ ... }:
+{
+  imports = [
+    ./system-defaults.nix
+  ];
+
+  # Platform / user
+  nixpkgs.hostPlatform = "aarch64-darwin";
+  system.primaryUser = "takuma";
+  users.users.takuma.home = "/Users/takuma";
+
+  # Enable flakes for the nix command.
+  nix.settings.experimental-features = [
+    "nix-command"
+    "flakes"
+  ];
+
+  # Manage /etc/zshrc so the nix environment is on PATH.
+  # The existing ~/.zshrc is sourced afterwards and stays untouched.
+  programs.zsh.enable = true;
+
+  # Used for backwards compatibility of stateful data. Bump only with care.
+  system.stateVersion = 5;
+}

--- a/darwin/system-defaults.nix
+++ b/darwin/system-defaults.nix
@@ -1,0 +1,54 @@
+# Migration of .osx (macOS `defaults write`) to declarative nix-darwin options.
+# `killall Finder/Dock` is unnecessary: darwin-rebuild's activation applies these.
+# `com.apple.dashboard mcx-disabled` is intentionally dropped (Dashboard is obsolete).
+{ ... }:
+{
+  system.defaults = {
+    finder = {
+      # Show hidden files
+      AppleShowAllFiles = true;
+      # Show full POSIX path in the window title
+      _FXShowPosixPathInTitle = true;
+    };
+
+    dock = {
+      # Speed up Mission Control animation
+      expose-animation-duration = 0.15;
+      # Show hidden apps translucently in the Dock
+      showhidden = true;
+    };
+
+    NSGlobalDomain = {
+      # Always expand the save dialog
+      NSNavPanelExpandedStateForSaveMode = true;
+      # Faster key repeat
+      InitialKeyRepeat = 12;
+      KeyRepeat = 1;
+    };
+
+    # Settings without a dedicated nix-darwin option go through the generic
+    # escape hatch (writes to the named preference domain verbatim).
+    CustomUserPreferences = {
+      "com.apple.finder" = {
+        # Allow text selection in QuickLook (legacy; may be a no-op on current macOS)
+        QLEnableTextSelection = true;
+      };
+      "com.apple.dock" = {
+        # Disable the spaces switch animation
+        "workspaces-swoosh-animation-off" = true;
+      };
+      ".GlobalPreferences" = {
+        # Trackpad tracking speed
+        "com.apple.trackpad.scaling" = 10.0;
+      };
+      "com.apple.desktopservices" = {
+        # Do not create .DS_Store on network volumes
+        DSDontWriteNetworkStores = true;
+      };
+      "com.apple.CrashReporter" = {
+        # Disable the crash report dialog
+        DialogType = "none";
+      };
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "valbeat dotfiles - nix-darwin configuration (Phase 1: system defaults)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nix-darwin.url = "github:nix-darwin/nix-darwin/master";
+    nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs =
+    { self, nixpkgs, nix-darwin }:
+    {
+      # Bootstrap: nix run nix-darwin -- switch --flake ~/dotfiles#takumas-MacBook-Pro
+      # Thereafter: darwin-rebuild switch --flake ~/dotfiles#takumas-MacBook-Pro
+      darwinConfigurations."takumas-MacBook-Pro" = nix-darwin.lib.darwinSystem {
+        system = "aarch64-darwin";
+        modules = [ ./darwin/configuration.nix ];
+      };
+    };
+}


### PR DESCRIPTION
設計メモ（#81）の Phase 1。`.osx` の macOS 設定を nix-darwin の宣言へ移行する最小構成。

## 追加ファイル
- `flake.nix` — nixpkgs-unstable + nix-darwin、host `takumas-MacBook-Pro`（aarch64-darwin）
- `darwin/configuration.nix` — プラットフォーム/ユーザー/flakes/zsh の基本設定
- `darwin/system-defaults.nix` — `.osx` 全項目の移植

## .osx → system.defaults 移植
- finder: AppleShowAllFiles / _FXShowPosixPathInTitle / QLEnableTextSelection
- dock: expose-animation-duration / showhidden / workspaces-swoosh-animation-off
- NSGlobalDomain: InitialKeyRepeat / KeyRepeat / NSNavPanelExpandedStateForSaveMode
- CustomUserPreferences: trackpad scaling / DSDontWriteNetworkStores / CrashReporter

## 判断
- `killall Finder/Dock` は darwin-rebuild の activation が自動化するため不要
- `com.apple.dashboard mcx-disabled` は obsolete のため移植せず
- `.osx` は移行確認まで残置（README に experimental として記載）
- flake input は現行公式の `nix-darwin/nix-darwin`（設計メモの LnL7 から更新）

## 未確認事項
- **Nix 未導入のため `nix flake check` は未実施**。Nix インストール（手動の前提条件）後に検証が必要
- bootstrap 後、Finder 隠しファイル表示・キーリピート等の反映を実機確認

## 次の手順
1. Nix インストール（READMEのコマンド）
2. `nix run nix-darwin -- switch --flake ~/dotfiles#takumas-MacBook-Pro`
3. 反映確認 → `.osx` を Makefile 対象から外す（別PR）→ Phase 2(Homebrew) へ

https://claude.ai/code/session_017q6Xu2uuGNLmsQWNe5Jwwq