### PR TITLE
chore(nix-darwin): add flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,49 @@
+{
+  "nodes": {
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781761792,
+        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-darwin",
+        "ref": "master",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nix-darwin": "nix-darwin",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}


### PR DESCRIPTION
Phase 1 (#82) で生成し損ねた `flake.lock` を追加。

## 内容
- `flake.lock` — inputs を固定
  - nixpkgs: `3e41b24`（2026-06-16）
  - nix-darwin: `a1fa429`（2026-06-18）

## ローカル検証済み
- `nix flake check` → ✅ `darwinConfigurations.takumas-MacBook-Pro`
- `nix build .#darwinConfigurations.takumas-MacBook-Pro.system` → ✅ ビルド成功（`darwin-system-26.11`）

## 次の手順（activation は sudo 必須のため手動）
ご自身のターミナルで:
```sh
sudo nix run nix-darwin -- switch --flake ~/dotfiles#takumas-MacBook-Pro
```

https://claude.ai/code/session_017q6Xu2uuGNLmsQWNe5Jwwq