### PR TITLE
chore: ignore Nix build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,14 @@ credentials
 # Ignore local config
 .gitconfig.local
 
+# === Nix / nix-darwin ===
+# Build output symlinks (point into /nix/store, must never be committed).
+# flake.nix / flake.lock / darwin/*.nix are intentionally tracked.
+result
+result-*
+# nix develop + direnv cache (.envrc is ignored in .gitignore_global)
+.direnv/
+
 .claude/*
 !.claude/settings.json
 !.claude/CLAUDE.md


### PR DESCRIPTION
nix 関連の gitignore を確認した結果、`result` シンボリックリンクの無視設定が欠けていたため追加。

## 背景（確認結果）
- `.gitignore` / `.gitignore_global` 共に nix 関連の記述なし
- `flake.nix` / `flake.lock` / `darwin/*.nix` は tracked（正しい。`flake.lock` は再現性のため必須）
- `nix build` / `darwin-rebuild build` が cwd に作る `result` symlink（`/nix/store` を指す）は**commit禁止**だが未無視だった

## 変更
`.gitignore` に追加:
- `result` / `result-*` — nix build 出力 symlink
- `.direnv/` — nix develop + direnv キャッシュ（`.envrc` は global で無視済み）

## 確認
- `git check-ignore result` → マッチ（無視される）
- `git check-ignore flake.lock` → マッチせず（tracked 維持）

https://claude.ai/code/session_017q6Xu2uuGNLmsQWNe5Jwwq