### PR TITLE
fix(nix-darwin): disable native Nix management for Determinate Nix

### DIFF
--- a/darwin/configuration.nix
+++ b/darwin/configuration.nix
@@ -9,11 +9,11 @@
   system.primaryUser = "takuma";
   users.users.takuma.home = "/Users/takuma";
 
-  # Enable flakes for the nix command.
-  nix.settings.experimental-features = [
-    "nix-command"
-    "flakes"
-  ];
+  # This host uses Determinate Nix, which manages the Nix installation with
+  # its own daemon. Disable nix-darwin's native Nix management to avoid the
+  # conflict. (nix-command/flakes are already enabled by Determinate, so the
+  # `nix.*` settings options are intentionally not used here.)
+  nix.enable = false;
 
   # Manage /etc/zshrc so the nix environment is on PATH.
   # The existing ~/.zshrc is sourced afterwards and stays untouched.


### PR DESCRIPTION
Phase 1 の activation が Determinate Nix との競合で失敗したため修正。

## エラー
```
error: Determinate detected, aborting activation
Determinate uses its own daemon to manage the Nix installation that
conflicts with nix-darwin’s native Nix management.
To turn off nix-darwin’s management of the Nix installation, set:
    nix.enable = false;
```

## 修正
`darwin/configuration.nix`:
- `nix.enable = false;` を追加（Determinate に Nix 管理を委譲）
- `nix.settings.experimental-features` を削除（nix管理OFF時は使えない。flakes/nix-command は Determinate が既に有効化済み）

## 検証（sudo不要のビルド）
- `nix flake check` → ✅
- `nix build .#darwinConfigurations.takumas-MacBook-Pro.system` → ✅ ビルド成功


https://claude.ai/code/session_017q6Xu2uuGNLmsQWNe5Jwwq