### PR TITLE
chore(coderabbit): review drafts + fix misplaced tools key

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,7 +14,7 @@ reviews:
   collapse_walkthrough: true
   auto_review:
     enabled: true
-    drafts: false
+    drafts: true
     base_branches:
       - main
   path_filters:
@@ -42,18 +42,17 @@ reviews:
       instructions: "冪等性 (再実行で二重適用されない marker チェック) とロールバック手段の有無を確認する。"
     - path: "**/CLAUDE.md"
       instructions: "ルールが具体的で、ファイル参照や手順が現存するか軽くチェックする。長文化を避ける指摘を優先する。"
-
-tools:
-  shellcheck:
-    enabled: true
-  markdownlint:
-    enabled: true
-  yamllint:
-    enabled: true
-  actionlint:
-    enabled: true
-  gitleaks:
-    enabled: true
+  tools:
+    shellcheck:
+      enabled: true
+    markdownlint:
+      enabled: true
+    yamllint:
+      enabled: true
+    actionlint:
+      enabled: true
+    gitleaks:
+      enabled: true
 
 knowledge_base:
   opt_out: false


### PR DESCRIPTION
CodeRabbit を draft PR でも有効にする。

## 変更（.coderabbit.yaml）
1. **draft でもレビュー**: `reviews.auto_review.drafts: false` → `true`
2. **無視されていた `tools` を修正**: top-level の `tools:` を `reviews.tools` 配下へ移動
   - top-level では未認識キーで、以前 #78 で `Unrecognized key: "tools"` と警告が出ていた
   - shellcheck / markdownlint / yamllint / actionlint / gitleaks が実際には適用されていなかったのを有効化

## 確認
- `python3 -c yaml.safe_load` で構文OK / `reviews.tools` に5ツール / top-level `tools` 解消を確認

このPR自体が draft なので、設定が効けば CodeRabbit がレビューを実行するはず（動作確認も兼ねる）。

https://claude.ai/code/session_017q6Xu2uuGNLmsQWNe5Jwwq