### PR TITLE
chore(brew): add pngpaste

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -273,6 +273,8 @@ brew "patchutils"
 brew "peco"
 # Draw UML diagrams
 brew "plantuml"
+# Save clipboard image as PNG (karabiner-config: iTerm2 Cmd+V image paste for Claude Code)
+brew "pngpaste"
 # PDF rendering library (based on the xpdf-3.0 code base)
 brew "poppler"
 # Show ps output as a tree


### PR DESCRIPTION
## 概要

`pngpaste` を Brewfile に追加する。

## なぜ

[karabiner-config](https://github.com/valbeat/karabiner-config) の iTerm2 Cmd+V 画像ペースト用スクリプト `scripts/iterm-claude-paste.sh` が `pngpaste` に依存するため。`brew bundle` で再現できるよう中央マニフェストに記載する。

このスクリプトは「iTerm2 が最前面のときの Cmd+V」を Karabiner でフックし、クリップボードの画像を PNG 保存してパスを Claude Code に渡す（テキスト/他アプリのペーストは無干渉）。背景:

- iTerm2 標準の Cmd+V は画像を base64 テキスト化する仕様（[iTerm2 docs](https://iterm2.com/documentation-images.html)）で Claude Code が画像として受け取れない
- iTerm2 では Ctrl+V 画像ペーストも断続的に失敗する既知問題（[claude-code#29365](https://github.com/anthropics/claude-code/issues/29365)）
- Cmd+V を 0x16 へ丸ごと再割り当てする案は全アプリのペーストを壊すため不可（[claude-code#16753](https://github.com/anthropics/claude-code/issues/16753)）

## 変更

- `Brewfile`: `brew "pngpaste"` を追加（alphabetical 順、由来コメント付き）

https://claude.ai/code/session_01Tdmiq2PzS8gRqhuj4EiUnZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for an additional Homebrew package in the setup, expanding available command-line tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->