### PR TITLE
chore(codex): keep codex trust entries out of version control

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/.codex/config.toml filter=codex-config

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 test: deploy ## Test for successful initialization
 DOTPATH    := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 CANDIDATES := $(wildcard .??*)
-EXCLUSIONS := .DS_Store .git .gitmodules .github
+EXCLUSIONS := .DS_Store .git .gitattributes .gitmodules .github
 DOTFILES   := $(filter-out $(EXCLUSIONS), $(CANDIDATES))
 
 .DEFAULT_GOAL := help
@@ -24,7 +24,13 @@ update: ## Fetch changes for this repo
 	@git submodule foreach git pull origin master
 
 .PHONY: install
-install: clean deploy ## Run make deploy, init
+install: clean deploy git-filters ## Run make deploy, init
+
+.PHONY: git-filters
+git-filters: ## Register git filters (strip codex trust entries from commits)
+	@git config filter.codex-config.clean "bash $(DOTPATH)/tools/git/codex-config-clean.sh"
+	@git config filter.codex-config.required true
+	@git -C $(DOTPATH) add --renormalize .codex/config.toml
 
 .PHONY: brew
 brew: ## Install packages from Brewfile

--- a/tools/git/codex-config-clean.sh
+++ b/tools/git/codex-config-clean.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# git clean filter for .codex/config.toml.
+# codex CLI appends per-machine [projects."<path>"] trust tables to the user
+# config on every "trust this repository" prompt. Strip them at stage time so
+# local trust state never enters version control.
+exec awk '
+  /^\[projects\./ || /^\[projects\]/ { skip = 1; next }
+  /^\[/ { skip = 0 }
+  {
+    if (skip) next
+    lines[++n] = $0
+  }
+  END {
+    while (n > 0 && lines[n] == "") n--
+    for (i = 1; i <= n; i++) print lines[i]
+  }
+'


### PR DESCRIPTION
## 背景

`~/.codex` は本リポジトリの `.codex` への symlink であり、codex CLI が新しいリポジトリを trust するたびに `[projects."<path>"]` の trust エントリをユーザー config（= tracked な `.codex/config.toml`）へ追記する。このためリポジトリが恒常的に dirty になっていた。

codex 側には trust 記録を別ファイルへ分離したり書き込みを抑止する設定は存在しない（[config reference](https://developers.openai.com/codex/config-reference) の `projects.<path>.trust_level` 参照）。

## 変更内容

- **git clean フィルタを追加**: stage 時に `[projects.*]` セクションを自動除去する `tools/git/codex-config-clean.sh` を追加し、`.gitattributes` で `.codex/config.toml` に適用
- **`make git-filters`**: フィルタを git config へ登録するターゲット。`make install` にも組み込み、新規マシンでも自動セットアップされる
- **`.gitattributes` を deploy 対象から除外**: `$HOME` へ symlink されないよう EXCLUSIONS に追加

## 動作

- trust エントリは worktree に残る（codex は今まで通り動作）が、diff / commit には一切含まれない
- model 変更などの意図した編集は従来通り diff に出る

## 既知の制約

- codex が**新しい** trust エントリを書いた直後は `git status` に `M` が一度表示される（diff は空でコミットもされない）。`git add .codex/config.toml`（no-op）または `make git-filters` で消える
- `git pull` で config.toml が更新されると worktree がクリーン内容で上書きされ、ローカルの trust エントリが消える。その場合 codex が各リポジトリで再度 trust を確認する

https://claude.ai/code/session_01Wswzp8TWZWoazhtuTs4iUZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated setup so installation now also configures Git filtering automatically.
  * Added support for treating certain repo dotfiles correctly during install.
  * Ensured one configuration file is cleaned and normalized before being stored, helping keep generated content consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->