### PR TITLE
feat: add enrich-issue command and simplify PR templates (legacy)

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,0 +1,184 @@
+# Create PR
+
+現在のブランチから、差分とコミットメッセージを基にPRを自動作成する。
+
+## Usage
+```
+Create PR
+```
+
+## Arguments (Optional)
+- `--base <branch>`: ベースブランチを指定 (デフォルト: main/master)
+- `--draft`: ドラフトPRとして作成
+- `--no-draft`: ドラフトではなく通常のPRとして作成
+
+## Steps
+
+1. **現在のブランチと状態を確認**
+   ```bash
+   # 現在のブランチ名を取得
+   git branch --show-current
+   
+   # コミット状態を確認
+   git status
+   
+   # リモートとの差分を確認
+   git fetch origin
+   git status -sb
+   ```
+
+2. **ベースブランチを特定**
+   ```bash
+   # デフォルトブランチを取得
+   gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+   
+   # または明示的に指定されたブランチを使用
+   BASE_BRANCH=${base:-$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)}
+   ```
+
+3. **変更内容を分析**
+   ```bash
+   # ベースブランチとの差分統計
+   git diff origin/$BASE_BRANCH...HEAD --stat
+   
+   # 変更ファイル一覧
+   git diff origin/$BASE_BRANCH...HEAD --name-status
+   
+   # 変更の詳細
+   git diff origin/$BASE_BRANCH...HEAD
+   ```
+
+4. **コミット履歴を収集**
+   ```bash
+   # コミット一覧
+   git log origin/$BASE_BRANCH..HEAD --oneline
+   
+   # 詳細なコミットメッセージ
+   git log origin/$BASE_BRANCH..HEAD --format="%s%n%b" | grep -v '^$'
+   ```
+
+5. **PRタイトルを生成**
+   - 最新のコミットメッセージまたは複数コミットの要約
+   - Conventional Commit形式を維持
+   - 例:
+     - 単一コミット: そのコミットメッセージを使用
+     - 複数コミット: 主要な変更を要約
+   ```bash
+   # 最新コミットのメッセージを取得
+   LATEST_COMMIT=$(git log -1 --format="%s")
+   
+   # コミット数を確認
+   COMMIT_COUNT=$(git rev-list --count origin/$BASE_BRANCH..HEAD)
+   
+   # タイトル決定
+   if [ $COMMIT_COUNT -eq 1 ]; then
+     PR_TITLE="$LATEST_COMMIT"
+   else
+     # 複数コミットの場合は要約を生成
+     PR_TITLE="feat: $(git log origin/$BASE_BRANCH..HEAD --format="%s" | head -1 | sed 's/^[^:]*: //')"
+   fi
+   ```
+
+6. **PR説明文を生成**
+   ```markdown
+   ## Summary
+   [変更の概要を自動生成]
+   
+   ## What Changed
+   [コミットメッセージから主要な変更を抽出してシンプルに記載]
+   - 新機能の追加内容
+   - 修正した問題
+   - 改善点
+   
+   ## Testing
+   - [ ] ローカルでテスト済み
+   - [ ] 関連するテストを追加/更新
+   
+   ## Related Issues
+   Closes #<issue-number> (該当する場合)
+   ```
+
+7. **ブランチをプッシュ**
+   ```bash
+   # 現在のブランチをリモートにプッシュ
+   git push -u origin HEAD
+   ```
+
+8. **PRを作成**
+   ```bash
+   # CLAUDE.mdの指定に従ってPRを作成
+   gh pr create \
+     --title "$PR_TITLE" \
+     --body "$PR_BODY" \
+     --base "$BASE_BRANCH" \
+     --assignee @me \
+     --draft
+   
+   # または --no-draft オプションが指定された場合
+   gh pr create \
+     --title "$PR_TITLE" \
+     --body "$PR_BODY" \
+     --base "$BASE_BRANCH" \
+     --assignee @me
+   ```
+
+9. **作成したPRを確認**
+   ```bash
+   # PRのURLを取得して表示
+   PR_URL=$(gh pr view --json url -q .url)
+   echo "PR created: $PR_URL"
+   
+   # ブラウザで開く（オプション）
+   gh pr view --web
+   ```
+
+## 自動生成ルール
+
+### タイトル生成
+1. **単一コミット**: コミットメッセージをそのまま使用
+2. **複数コミット（同一タイプ）**: タイプを維持して要約
+3. **複数コミット（異なるタイプ）**: 最も重要な変更のタイプを使用
+4. **優先順位**: feat > fix > refactor > その他
+
+### 説明文生成
+1. **Summary**: 変更の目的と影響を1-3文で要約
+2. **What Changed**: 主要な変更点のみをシンプルに記載
+3. **Breaking Changes**: "BREAKING CHANGE" を含む場合のみ追加
+4. **Issue References**: #番号 パターンを自動検出
+
+## Gemini連携オプション
+
+より詳細な説明を生成する場合：
+```bash
+gemini <<EOF
+役割: PRレビュアー/テクニカルライター
+タスク: 以下の情報からPRタイトルと説明を生成
+入力:
+- 差分: $(git diff origin/$BASE_BRANCH...HEAD)
+- コミット: $(git log origin/$BASE_BRANCH..HEAD --format="%s%n%b")
+- 変更ファイル: $(git diff origin/$BASE_BRANCH...HEAD --name-status)
+要件:
+- Conventional Commit形式のタイトル
+- 変更の意図と影響を明確に説明
+- レビュアーが理解しやすい構成
+出力: 
+- title: [PRタイトル]
+- body: [PR説明文（Markdown）]
+EOF
+```
+
+## エラーハンドリング
+
+### よくある問題と対処
+1. **未プッシュのコミット**: 自動的にプッシュ
+2. **ブランチ名の重複**: 既存PRの確認と警告
+3. **ベースブランチが古い**: fetchして最新化
+4. **コンフリクト**: 警告を表示してユーザーに解決を促す
+
+## Notes
+
+- CLAUDE.md の Git Workflow セクションに従って `--assignee @me --draft` を使用
+- デフォルトでドラフトPRとして作成（CLAUDE.mdの指定通り）
+- PR作成後、必要に応じて手動でレビュー準備完了にする
+- 既存のPRがある場合は警告を表示
+- コミットメッセージが適切に書かれていることが前提

--- a/.claude/commands/enrich-issue.md
+++ b/.claude/commands/enrich-issue.md
@@ -1,0 +1,237 @@
+# Enrich Issue
+
+GitHub Issueの内容を分析し、プロジェクトのドキュメントやコーディング規約を参照して実装計画や仕様を詳細に補足する。
+
+## Usage
+```
+Enrich issue #<issue-number>
+```
+
+## Arguments (Optional)
+- `--mode <type>`: 補足モード (spec|plan|both) デフォルト: both
+  - `spec`: 技術仕様の詳細化
+  - `plan`: 実装計画の作成
+  - `both`: 両方を生成
+
+## Steps
+
+1. **Issueの現在の内容を取得**
+   ```bash
+   # Issue情報を取得
+   gh issue view <issue-number> --json title,body,labels,assignees,milestone
+   
+   # コメントも含めて取得
+   gh issue view <issue-number> --comments
+   ```
+
+2. **プロジェクトコンテキストの収集**
+   ```bash
+   # プロジェクトのREADMEを確認
+   cat README.md
+   
+   # CLAUDE.mdの規約を確認
+   cat CLAUDE.md
+   cat .claude/CLAUDE.md
+   
+   # 関連ドキュメントの検索
+   find . -name "*.md" -type f | grep -E "(CONTRIBUTING|ARCHITECTURE|DESIGN|SPEC)"
+   
+   # package.jsonやその他の設定ファイル
+   cat package.json 2>/dev/null || cat Cargo.toml 2>/dev/null
+   ```
+
+3. **関連コードベースの分析**
+   ```bash
+   # Issueタイトルから関連キーワードを抽出
+   # 例: "認証機能" -> auth, authentication, login
+   
+   # 関連ファイルを検索
+   rg -l "<keyword>" --type-add 'code:*.{js,ts,tsx,jsx,py,rs,go}'
+   
+   # 既存の実装パターンを確認
+   rg -A 5 -B 5 "<pattern>" --type-add 'code:*.{js,ts,tsx,jsx,py,rs,go}'
+   ```
+
+4. **技術仕様の詳細化**
+   ```markdown
+   ## 技術仕様
+   
+   ### 概要
+   [Issueの要件を技術的に解釈]
+   
+   ### アーキテクチャ
+   - 全体構成
+   - コンポーネント設計
+   - データフロー
+   
+   ### インターフェース定義
+   - API仕様
+   - 型定義
+   - 入出力形式
+   
+   ### 実装詳細
+   - 使用する技術/ライブラリ
+   - アルゴリズム
+   - データ構造
+   
+   ### 制約事項
+   - パフォーマンス要件
+   - セキュリティ考慮事項
+   - 互換性要件
+   ```
+
+5. **実装計画の作成**
+   ```markdown
+   ## 実装計画
+   
+   ### フェーズ分割
+   1. **Phase 1: 基盤準備**
+      - [ ] 必要なパッケージのインストール
+      - [ ] 基本構造の作成
+      - [ ] 設定ファイルの準備
+   
+   2. **Phase 2: コア機能実装**
+      - [ ] メイン機能の実装
+      - [ ] ユニットテストの作成
+      - [ ] エラーハンドリング
+   
+   3. **Phase 3: 統合と最適化**
+      - [ ] 既存システムとの統合
+      - [ ] パフォーマンス最適化
+      - [ ] 統合テスト
+   
+   ### タスクブレークダウン
+   - タスク1: [具体的な作業内容] (推定: Xh)
+   - タスク2: [具体的な作業内容] (推定: Xh)
+   
+   ### 依存関係
+   - 外部ライブラリ
+   - 他のIssue/PR
+   - 環境要件
+   ```
+
+6. **受け入れ基準の明確化**
+   ```markdown
+   ## 受け入れ基準
+   
+   ### 機能要件
+   - [ ] [具体的な動作条件1]
+   - [ ] [具体的な動作条件2]
+   
+   ### 非機能要件
+   - [ ] パフォーマンス: [具体的な基準]
+   - [ ] セキュリティ: [具体的な基準]
+   - [ ] 使いやすさ: [具体的な基準]
+   
+   ### テスト要件
+   - [ ] ユニットテストカバレッジ: X%以上
+   - [ ] E2Eテストシナリオ
+   - [ ] エッジケースの考慮
+   ```
+
+7. **Issueの更新**
+   ```bash
+   # 既存の内容に追記する形で更新
+   gh issue edit <issue-number> --body "$(cat <<EOF
+   [既存の内容]
+   
+   ---
+   ## 📋 詳細仕様 (AI-Enhanced)
+   
+   [生成した技術仕様]
+   
+   [生成した実装計画]
+   
+   [生成した受け入れ基準]
+   
+   ### 🔗 参照したドキュメント
+   - CLAUDE.md
+   - README.md
+   - [その他参照したファイル]
+   
+   ### 📝 Notes
+   - この仕様は既存のコードベースとプロジェクト規約に基づいて生成されました
+   - 実装時は最新の状態を確認してください
+   EOF
+   )"
+   ```
+
+8. **ラベルの追加（必要に応じて）**
+   ```bash
+   # 仕様詳細化済みのラベルを追加
+   gh issue edit <issue-number> --add-label "spec-defined"
+   
+   # 実装準備完了のラベルを追加
+   gh issue edit <issue-number> --add-label "ready-for-implementation"
+   ```
+
+## Gemini連携オプション
+
+より詳細な分析が必要な場合：
+```bash
+gemini <<EOF
+役割: ソフトウェアアーキテクト/テクニカルライター
+タスク: GitHub Issue #<number> の内容を基に詳細な技術仕様と実装計画を作成
+入力:
+- Issue内容: $(gh issue view <number>)
+- プロジェクト規約: $(cat CLAUDE.md)
+- 関連コード: $(rg -A 10 -B 10 "<keyword>")
+要件:
+- プロジェクトの既存パターンに従う
+- 実装可能な具体的な計画
+- テスト戦略を含む
+出力形式:
+1. 技術仕様（Markdown）
+2. 実装計画（タスクリスト形式）
+3. 受け入れ基準（チェックリスト）
+EOF
+```
+
+## コーディング規約の自動抽出
+
+プロジェクトから規約を学習：
+```bash
+# コーディングスタイルの分析
+# - インデント（スペース/タブ）
+# - 命名規則（camelCase/snake_case）
+# - コメントスタイル
+# - ファイル構成パターン
+
+# 使用ライブラリの確認
+# - package.json dependencies
+# - import文のパターン
+# - 頻出するユーティリティ
+
+# テストパターンの確認
+# - テストフレームワーク
+# - テストファイルの配置
+# - モック/スタブの使い方
+```
+
+## 注意事項
+
+- Issueの既存内容は保持し、追記形式で更新
+- プロジェクト固有の規約を優先
+- 実装の実現可能性を考慮
+- 過度に詳細になりすぎないようバランスを取る
+- チーム固有の用語や略語を尊重
+
+## Examples
+
+### シンプルなバグ修正Issue
+```bash
+@enrich-issue 42 --mode plan
+# → 修正手順とテスト計画を生成
+```
+
+### 新機能のIssue
+```bash
+@enrich-issue 100 --mode both
+# → 完全な技術仕様と段階的な実装計画を生成
+```
+
+### 仕様のみ必要な場合
+```bash
+@enrich-issue 55 --mode spec
+# → API仕様、データモデル、インターフェース定義を生成
+```

--- a/.claude/commands/update-pr.md
+++ b/.claude/commands/update-pr.md
@@ -1,0 +1,139 @@
+# Update PR
+
+GitHub PRのタイトルと説明を、ベースブランチとの差分やコミットメッセージを基に自動更新する。
+
+## Usage
+```
+Update PR #<pr-number>
+```
+
+## Steps
+
+1. **PRの現在の情報を取得**
+   ```bash
+   # PR情報を取得
+   gh pr view <pr-number> --json title,body,baseRefName,headRefName
+   
+   # PRブランチにチェックアウト
+   gh pr checkout <pr-number>
+   ```
+
+2. **ベースブランチとの差分を分析**
+   ```bash
+   # ベースブランチの最新を取得
+   git fetch origin
+   
+   # ベースブランチとの差分を確認
+   git diff origin/<base-branch>...HEAD --stat
+   
+   # 変更されたファイルの詳細
+   git diff origin/<base-branch>...HEAD --name-status
+   ```
+
+3. **コミットメッセージを収集**
+   ```bash
+   # PRに含まれるコミットを取得
+   git log origin/<base-branch>..HEAD --oneline
+   
+   # 詳細なコミットメッセージを取得
+   git log origin/<base-branch>..HEAD --format="- %s%n%b"
+   ```
+
+4. **変更内容を分析して要約**
+   - 主要な変更の識別
+   - 機能追加、バグ修正、リファクタリング等の分類
+   - 影響範囲の特定
+   - 技術的詳細の抽出
+
+5. **PRタイトルの生成**
+   ```bash
+   # Conventional Commit形式でタイトルを生成
+   # 例: "feat: add user authentication system"
+   #     "fix: resolve memory leak in data processor"
+   #     "refactor: improve database query performance"
+   ```
+
+6. **PR説明文の生成**
+   ```markdown
+   ## Summary
+   [変更の概要を1-3文で記載]
+   
+   ## What Changed
+   [主要な変更点のみをシンプルに記載]
+   
+   ## Why
+   [変更の理由や背景（必要に応じて）]
+   
+   ## Testing
+   - [ ] テスト済み
+   - [ ] 関連テストを追加/更新
+   
+   ## Related Issues
+   Closes #<issue-number> (該当する場合)
+   ```
+
+7. **PRの更新**
+   ```bash
+   # タイトルのみ更新
+   gh pr edit <pr-number> --title "<new-title>"
+   
+   # 説明のみ更新
+   gh pr edit <pr-number> --body "<new-body>"
+   
+   # タイトルと説明を同時に更新
+   gh pr edit <pr-number> --title "<new-title>" --body "<new-body>"
+   ```
+
+8. **更新内容の確認**
+   ```bash
+   # 更新後のPR情報を表示
+   gh pr view <pr-number>
+   
+   # ブラウザで確認
+   gh pr view <pr-number> --web
+   ```
+
+## オプション
+
+### インタラクティブモード
+```bash
+# 生成された内容を確認してから更新
+gh pr edit <pr-number> --title "<title>" --body "<body>" --editor
+```
+
+### Gemini連携モード
+Gemini CLIと連携して、より詳細な説明を生成：
+```bash
+gemini <<EOF
+役割: テクニカルライター
+タスク: 以下のgit差分とコミットメッセージから、PRの説明文を生成
+コンテキスト: 
+- 差分: $(git diff origin/<base>...HEAD)
+- コミット: $(git log origin/<base>..HEAD)
+制約条件: 
+- 技術的に正確であること
+- 簡潔で分かりやすいこと
+出力形式: Markdown形式のPR説明文
+EOF
+```
+
+## 自動生成のガイドライン
+
+### タイトル
+- Conventional Commit形式を使用
+- 50文字以内で要約
+- 動詞で始める（add, fix, update, refactor等）
+
+### 説明文
+- **Summary**: 何を・なぜ変更したかを簡潔に
+- **What Changed**: 主要な変更点のみ記載
+- **Why**: 変更の理由（必要に応じて）
+- **Breaking Changes**: 破壊的変更がある場合は明記
+- **Testing**: テスト状況をチェックボックスで
+
+## Notes
+
+- PRの作成者でない場合、編集権限がない可能性がある
+- 既存の説明を完全に置き換えるため、手動で追加した情報は保持されない
+- 必要に応じて `--editor` オプションで手動編集が可能
+- コミットメッセージが適切に書かれていると、より良い説明が生成される


### PR DESCRIPTION
## Summary

未マージのまま残っていた 2020年代の作業ブランチをレビュー用にPR化したもの。`.claude/commands/` 配下に create-pr / enrich-issue / update-pr の3コマンドを追加する内容。

## ⚠️ 注意: 内容は現行のskillsに置き換え済みの可能性が高い

このブランチの3ファイルは、現在 `main` に存在する以下のスキルに相当します:

- `create-pr.md` → `.claude/skills/pr/SKILL.md`
- `enrich-issue.md` → `.claude/skills/issue/SKILL.md`
- `update-pr.md` → `.claude/skills/update-pr/SKILL.md`

差分をレビューして、skillsに未反映のアイデアがなければ**マージせずクローズ＋ブランチ削除**を推奨。取り込みたい記述があれば該当スキルへ移植する。

https://claude.ai/code/session_01SJfQNVKrbmKHTeyh1FtZzi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guides for creating, enriching, and updating GitHub pull requests and issues.
  * Documented step-by-step workflows, command options, output formats, and example usage.
  * Included guidance for generating titles and descriptions, handling common issues, and updating content with AI-assisted workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->