### PR TITLE
chore(config): enable Claude notifications and git fetch pruning

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -52,7 +52,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.config/iterm2/cc-status"
+            "command": "~/.config/iterm2/cc-status",
+            "async": true
           }
         ]
       }
@@ -79,7 +80,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.config/iterm2/cc-status"
+            "command": "~/.config/iterm2/cc-status",
+            "async": true
           }
         ]
       }
@@ -89,7 +91,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.config/iterm2/cc-status"
+            "command": "~/.config/iterm2/cc-status",
+            "async": true
           }
         ]
       }
@@ -99,7 +102,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.config/iterm2/cc-status"
+            "command": "~/.config/iterm2/cc-status",
+            "async": true
           }
         ]
       }
@@ -109,7 +113,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.config/iterm2/cc-status"
+            "command": "~/.config/iterm2/cc-status",
+            "async": true
           }
         ]
       }
@@ -119,7 +124,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.config/iterm2/cc-status"
+            "command": "~/.config/iterm2/cc-status",
+            "async": true
           }
         ]
       }
@@ -129,7 +135,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.config/iterm2/cc-status"
+            "command": "~/.config/iterm2/cc-status",
+            "async": true
           }
         ]
       }
@@ -139,7 +146,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.config/iterm2/cc-status"
+            "command": "~/.config/iterm2/cc-status",
+            "async": true
           }
         ]
       }
@@ -149,7 +157,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.config/iterm2/cc-status"
+            "command": "~/.config/iterm2/cc-status",
+            "async": true
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,6 +48,14 @@
             "command": "~/.claude/hooks/guard.sh"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.config/iterm2/cc-status"
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -65,6 +73,84 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/log-tooluse.sh"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.config/iterm2/cc-status"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.config/iterm2/cc-status"
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.config/iterm2/cc-status"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.config/iterm2/cc-status"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.config/iterm2/cc-status"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.config/iterm2/cc-status"
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.config/iterm2/cc-status"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.config/iterm2/cc-status"
           }
         ]
       }

--- a/.gitconfig
+++ b/.gitconfig
@@ -168,3 +168,5 @@
 [user]
 	name = Takuma Kajikawa
 	email = kj1ktk@gmail.com
+[fetch]
+	prune = true


### PR DESCRIPTION
## Summary

未マージのまま残っていたローカルブランチ `chore/coderabbit-draft-review` 上のコミット `32882fd`（2026-06-24）をPR化したもの。iTerm2 の `cc-status` によるClaude Code通知統合と、git の fetch pruning を有効化する。

## Changes

- `.claude/settings.json`: `~/.config/iterm2/cc-status` を9つのhookイベント（Notification / PermissionRequest / SessionStart / SessionEnd / Stop / StopFailure / UserPromptSubmit / PreToolUse / PostToolUse）に配線
- `.gitconfig`: `[fetch] prune = true` を追加

## 元コミットからの変更点（コンフリクト解決の方針）

元コミットは `settings.json` 全体をツール書き出し形式で上書きしており、そのまま適用するとmainの新しい設定（default model、UI設定等）を巻き戻してしまうため、以下の方針で解決した:

- mainの `settings.json` を基準に、**cc-status のhook配線のみを追加**（純増86行、削除なし）
- 通知フラグ（`agentPushNotifEnabled` / `inputNeededNotifEnabled`）は既にmainに反映済みのため対象外
- hookのパスは絶対パス `/Users/takuma/...` から `~/...` に正規化（既存hookの表記に統一）
- `~/.config/iterm2/cc-status` が実在することは確認済み

## Testing

- `python3 -m json.tool` で settings.json のJSON妥当性を確認
- `git diff main` が追加のみ（既存設定の変更なし）であることを確認

https://claude.ai/code/session_01SJfQNVKrbmKHTeyh1FtZzi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new status command that runs automatically during several app events, keeping terminal/session status updates more responsive.
* **Chores**
  * Enabled automatic cleanup of stale remote-tracking branches during Git fetches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->