### PR TITLE
feat(claude): add herdr-* skills mirroring cmux skill family

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -144,3 +144,30 @@ cmux identify --json &>/dev/null
 
 - cmux 内で実行中の場合、`cmux-*` スキル群を積極的に活用する
 - 各スキルの description にトリガーフレーズが定義されているため、自然言語で自動選択される
+
+## herdr Integration
+
+ターミナルネイティブ（TUI + headless サーバ、SSH リモート対応）のワークスペースマネージャー。cmux の GUI が使えない／リモート・ヘッドレス環境では herdr 系スキルを使う。cmux 系スキルと1:1対応する `herdr-*` スキルを用意している。
+
+### herdr / cmux の使い分け
+
+- `CMUX_WORKSPACE_ID` が設定されている（= cmux 内）→ **cmux 系スキルを優先**
+- cmux 外で、`herdr status server` が `status: running` を返す → **herdr 系スキルを使う**
+- SSH リモート・ヘッドレス・軽量に済ませたい → herdr（`herdr --remote` でリモートアタッチ）
+
+### スキル対応表
+
+| herdr | cmux | 役割 |
+|-------|------|------|
+| `herdr-core` | `cmux` | トポロジ制御（workspace/tab/pane/worktree） |
+| `herdr-agent` | `cmux-agent` | headless サブエージェント起動 |
+| `herdr-fork` | `cmux-fork` | 現セッションを split pane にフォーク |
+| `herdr-team` | `cmux-team` | 4層マルチエージェントオーケストレーション |
+| （なし） | `cmux-browser` | herdr は webview 非対応 → `claude-in-chrome` MCP で代替 |
+| （なし） | `cmux-markdown` | herdr は GUI ビューア非対応 |
+
+### herdr の CLI 要点
+
+- socket API 系サブコマンドは `{"id":..,"result":{..}}` 形状の JSON を返す。`jq` で `.result` 配下を参照
+- エージェント完了検知は画面 grep ではなく **`herdr wait agent-status <pane> --status idle`**（per-pane の agent_status をネイティブ追跡）が信頼できる
+- worktree は `herdr worktree create --branch … --base …` でブランチと workspace を一括生成

--- a/.claude/skills/herdr-agent/SKILL.md
+++ b/.claude/skills/herdr-agent/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: herdr-agent
+description: >-
+  Spawn a headless Claude Code sub-agent in a new herdr workspace, send it a
+  prompt, and collect results. Use when user says "spawn agent",
+  "エージェント起動", "サブエージェントで", "delegate task", "タスク委任",
+  "バックグラウンドで実行", or when another skill needs parallel task execution
+  in a herdr session. herdr counterpart of the cmux-agent skill.
+allowed-tools: Bash
+argument-hint: "<prompt> [--name task-name] [--wait]"
+---
+
+# herdr Sub-Agent
+
+Spawn a Claude Code sub-agent in a dedicated herdr workspace, send a task prompt, and
+optionally wait for completion. Terminal-native counterpart of `cmux-agent`.
+
+Unlike cmux (which greps the screen for an idle prompt), herdr tracks **per-pane
+`agent_status`** natively, so use `herdr wait agent-status --status idle` for reliable
+completion detection.
+
+## Your Task
+
+1. Parse args: the prompt, optional `--name` (default `agent-{timestamp}`), and `--wait`.
+2. Run the spawn sequence.
+3. If `--wait`: block on `agent-status idle`, then read and return results.
+4. If no `--wait`: report the workspace/pane refs so the user can check later.
+
+## Spawn Sequence
+
+```bash
+TASK_NAME="${NAME:-agent-$(date +%s)}"
+
+# 1. Create a dedicated workspace; capture workspace + root pane refs
+CREATE=$(herdr workspace create --label "$TASK_NAME" --no-focus)
+WS=$(echo "$CREATE" | jq -r '.result.workspace.workspace_id')
+P=$(echo  "$CREATE" | jq -r '.result.root_pane.pane_id')
+
+# 2. Launch Claude Code (headless, autonomous)
+herdr pane run "$P" "claude --dangerously-skip-permissions"
+
+# 3. Wait until Claude is ready to accept input
+herdr wait output "$P" --match '(❯|>|Claude Code)' --regex --timeout 30000 || \
+  echo "warning: prompt not detected within 30s — check with: herdr pane read $P"
+
+# 4. Send the task prompt and submit
+herdr pane send-text "$P" "$PROMPT"
+herdr pane send-keys "$P" Enter
+
+echo "Agent spawned: workspace=$WS pane=$P task=$TASK_NAME"
+```
+
+## Wait for Completion (--wait)
+
+```bash
+# Block until the agent goes idle (finished responding)
+herdr wait agent-status "$P" --status idle --timeout 1800000
+
+# Collect the result (recent scrollback)
+herdr pane read "$P" --source recent --lines 500
+```
+
+## Collect Results (no --wait, check later)
+
+```bash
+herdr pane read "$P" --source recent --lines 500
+
+# Or poll status once
+herdr pane get "$P" | jq -r '.result.pane.agent_status // .result.agent_status'
+```
+
+## Cleanup
+
+```bash
+herdr workspace close "$WS"
+```
+
+## Multi-Agent Pattern
+
+```bash
+declare -a PANES
+for TASK in "review models/" "review controllers/" "review middleware/"; do
+  TASK_NAME="review-$(echo "$TASK" | tr ' /' '-')"
+  CREATE=$(herdr workspace create --label "$TASK_NAME" --no-focus)
+  P=$(echo "$CREATE" | jq -r '.result.root_pane.pane_id')
+  herdr pane run "$P" "claude --dangerously-skip-permissions"
+  herdr wait output "$P" --match '(❯|>|Claude Code)' --regex --timeout 30000
+  herdr pane send-text "$P" "$TASK"
+  herdr pane send-keys "$P" Enter
+  PANES+=("$P")
+  echo "$TASK_NAME: pane=$P"
+done
+
+# Later: wait for all, then read each
+for P in "${PANES[@]}"; do
+  herdr wait agent-status "$P" --status idle --timeout 1800000
+  echo "=== $P ==="; herdr pane read "$P" --source recent --lines 200
+done
+```
+
+## Notes
+
+- `pane send-text` writes **literal text only**; always follow with `pane send-keys Enter`
+  to submit. Use `pane run` for a command that should include Enter automatically.
+- If the `claude` integration is installed (`herdr integration install claude`), herdr
+  will label the pane's agent automatically and `herdr agent list` will show it; you can
+  then target it by name via `herdr agent send/read/wait`.
+
+## Error Handling
+
+- `herdr` not found → report that herdr CLI is not installed.
+- `workspace create` returns `{"error":...}` → run `herdr status server`; start with
+  `herdr` if the server is down, then retry.
+- Prompt not detected in 30s → report timeout; inspect with `herdr pane read $P --lines 40`.
+- `wait agent-status` times out → the agent may be blocked on input; read the pane and
+  send any required response with `pane send-text` + `pane send-keys Enter`.
+
+## Related Skills
+
+| Skill | When to Use |
+|-------|-------------|
+| [../herdr-core/SKILL.md](../herdr-core/SKILL.md) | Core topology control (workspaces, tabs, panes, worktrees) |
+| [../herdr-fork/SKILL.md](../herdr-fork/SKILL.md) | Fork the current session (interactive, not headless) |
+| [../herdr-team/SKILL.md](../herdr-team/SKILL.md) | Multi-agent orchestration (4-layer hierarchy) |
+| [../cmux-agent/SKILL.md](../cmux-agent/SKILL.md) | Same role, but for the cmux GUI app |

--- a/.claude/skills/herdr-core/SKILL.md
+++ b/.claude/skills/herdr-core/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: herdr-core
+description: >-
+  Control herdr topology and routing — sessions, workspaces, tabs, panes,
+  focus, splits, moves, swaps, zoom, and worktrees over the socket API.
+  Use when user says "split pane", "new workspace", "move pane",
+  "list workspaces", "レイアウト変更", or needs deterministic placement in a
+  herdr terminal session. herdr counterpart of the cmux skill.
+allowed-tools: Bash
+---
+
+# herdr Core Control
+
+Use this skill to control herdr topology and routing via the socket API (`herdr <sub>`).
+This is the terminal-native counterpart of the `cmux` skill.
+
+## When to prefer this over cmux
+
+- Inside a herdr session, over SSH (`herdr --remote`), or any headless/terminal-only
+  context. Confirm the server with `herdr status server` (expect `status: running`).
+- If `CMUX_WORKSPACE_ID` is set, you are inside cmux — prefer the `cmux` skill instead.
+
+## Core Concepts
+
+- **Session**: persistent server-backed session (survives detach). Named via `--session`.
+- **Workspace**: top-level group with its own cwd (≈ cmux workspace).
+- **Tab**: a tab within a workspace (≈ cmux surface).
+- **Pane**: split container inside a tab where a shell/agent runs.
+
+## Handle Model
+
+- Refs look like `w1` (workspace), `w1:t1` (tab), `w1:p1` (pane).
+- All socket-API subcommands emit JSON as `{"id":...,"result":{...}}`. Parse with `jq`
+  under `.result`. Errors come back as `{"error":{"code","message"}}`.
+
+## Fast Start
+
+```bash
+# status / topology
+herdr status server
+herdr workspace list | jq -c '.result.workspaces[] | {workspace_id,label,agent_status}'
+herdr tab list       | jq -c '.result.tabs[]       | {tab_id,label}'
+herdr pane list      | jq -c '.result.panes[]      | {pane_id,cwd,agent_status,focused}'
+
+# create / focus
+WS=$(herdr workspace create --label mytask --no-focus | jq -r '.result.workspace.workspace_id')
+herdr workspace focus "$WS"
+herdr tab create --workspace "$WS" --label build --no-focus
+
+# split / navigate / arrange
+P=$(herdr pane split w1:p1 --direction right --ratio 0.5 --no-focus | jq -r '.result.pane.pane_id')
+herdr pane focus --direction left
+herdr pane swap  --direction right
+herdr pane zoom  --toggle
+herdr pane resize --direction right --amount 0.1
+
+# move a pane to a new tab / workspace
+herdr pane move "$P" --new-tab --label logs
+herdr pane move "$P" --new-workspace --label scratch
+
+# read / send into a pane
+herdr pane read "$P" --source recent --lines 80
+herdr pane send-text "$P" "echo hi"
+herdr pane send-keys "$P" Enter
+herdr pane run "$P" "make check"     # command text + Enter in one call
+
+# attention cue (herdr's flash equivalent)
+herdr notification show "Done" --sound done
+```
+
+## Worktree Helpers
+
+herdr has first-class git worktree support — the core of parallel-branch workflows.
+
+```bash
+herdr worktree list | jq -c '.result.worktrees[] | {branch,path,open_workspace_id}'
+
+# create a worktree + its workspace in one shot
+herdr worktree create --branch feat/foo --base main --label foo --focus
+# open an existing branch/path as a workspace
+herdr worktree open --branch feat/foo --focus
+# remove
+herdr worktree remove --workspace <ID> --force
+```
+
+## Cleanup
+
+```bash
+herdr pane close <pane_id>
+herdr tab close <tab_id>
+herdr workspace close <workspace_id>
+```
+
+## Error Handling
+
+- `herdr` not found → report that herdr CLI is not installed.
+- Command returns `{"error":...}` → run `herdr status server`; if not running, `herdr` (or
+  `herdr --session <name>`) starts it. Then re-list refs and retry.
+- Invalid ref → re-discover with `herdr workspace list` / `herdr pane list`.
+- Pass **raw ref strings** (e.g. `w1:p1`), never a jq-extracted JSON object.
+
+## Related Skills
+
+| Skill | When to Use |
+|-------|-------------|
+| [../herdr-agent/SKILL.md](../herdr-agent/SKILL.md) | Spawn a headless sub-agent in a new workspace |
+| [../herdr-fork/SKILL.md](../herdr-fork/SKILL.md) | Fork the current Claude session into a split pane |
+| [../herdr-team/SKILL.md](../herdr-team/SKILL.md) | Multi-agent orchestration (4-layer hierarchy) |
+| [../cmux/SKILL.md](../cmux/SKILL.md) | Same role, but for the cmux GUI app |
+
+> No herdr equivalent of `cmux-browser` (herdr is terminal-only, no webview).
+> For browser automation use the `claude-in-chrome` MCP tools instead.

--- a/.claude/skills/herdr-fork/SKILL.md
+++ b/.claude/skills/herdr-fork/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: herdr-fork
+description: >-
+  Fork the current Claude Code session into a new herdr split pane with
+  --continue --fork-session. Use when user says "fork", "split claude",
+  "別ペインで", "フォーク", "並列セッション", or needs a parallel Claude session
+  in a herdr terminal. herdr counterpart of the cmux-fork skill.
+allowed-tools: Bash
+argument-hint: "[direction: right|down] (default: right)"
+---
+
+# herdr Fork Session
+
+Fork the current Claude Code session into a new herdr split pane. Terminal-native
+counterpart of `cmux-fork`.
+
+> Note: herdr splits are `right` or `down` only (no `left`/`up` at split time — use
+> `herdr pane swap`/`move` afterward to reposition). Default: `right`.
+
+## Your Task
+
+1. Parse the direction argument (default `right`; valid: `right`, `down`).
+2. Determine the current pane, split it, and launch a forked session in the new pane.
+3. Report the new pane ref to the user.
+
+## Commands
+
+```bash
+DIR="${DIRECTION:-right}"
+
+# Current pane ref (the pane this session runs in)
+CUR=$(herdr pane current --current | jq -r '.result.pane.pane_id // .result.pane_id')
+
+# Split and capture the new pane ref
+P=$(herdr pane split "$CUR" --direction "$DIR" --ratio 0.5 --focus | jq -r '.result.pane.pane_id')
+
+# Fork the current session in the new pane
+herdr pane run "$P" "claude --continue --fork-session"
+
+echo "Forked session on pane $P (split $DIR)"
+```
+
+## Examples
+
+```bash
+# Split right (default)
+P=$(herdr pane split "$(herdr pane current --current | jq -r '.result.pane.pane_id // .result.pane_id')" \
+      --direction right --focus | jq -r '.result.pane.pane_id')
+herdr pane run "$P" "claude --continue --fork-session"
+
+# Split down
+P=$(herdr pane split "$(herdr pane current --current | jq -r '.result.pane.pane_id // .result.pane_id')" \
+      --direction down --focus | jq -r '.result.pane.pane_id')
+herdr pane run "$P" "claude --continue --fork-session"
+```
+
+## Error Handling
+
+- `herdr` not found → report that herdr CLI is not installed.
+- `pane current` fails → you may not be running inside a herdr pane; fall back to
+  `herdr pane list` and pick the focused pane (`.result.panes[] | select(.focused)`).
+- `pane split` returns `{"error":...}` → run `herdr pane list` to verify topology, report
+  the error.
+- `pane run` fails → report the pane ref and suggest launching `claude --continue
+  --fork-session` there manually.
+
+## Related Skills
+
+| Skill | When to Use |
+|-------|-------------|
+| [../herdr-core/SKILL.md](../herdr-core/SKILL.md) | Topology control (workspaces, tabs, panes, worktrees) |
+| [../herdr-agent/SKILL.md](../herdr-agent/SKILL.md) | Spawn a headless sub-agent in a new workspace |
+| [../herdr-team/SKILL.md](../herdr-team/SKILL.md) | Multi-agent orchestration (4-layer hierarchy) |
+| [../cmux-fork/SKILL.md](../cmux-fork/SKILL.md) | Same role, but for the cmux GUI app |

--- a/.claude/skills/herdr-team/SKILL.md
+++ b/.claude/skills/herdr-team/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: herdr-team
+description: >-
+  Multi-agent orchestration framework with 4-layer hierarchy —
+  Master, Manager, Conductor, Agent. Manages parallel sub-agents in
+  git worktrees via herdr. Use when user says "team start", "チーム起動",
+  "マルチエージェント", "parallel tasks", "並列タスク実行", or needs to run
+  multiple autonomous agents on separate tasks in a herdr session.
+  herdr counterpart of the cmux-team skill.
+allowed-tools: Bash
+argument-hint: "<task-list or goal> [--agents N]"
+---
+
+# herdr Team Orchestration
+
+4-layer agent hierarchy for autonomous multi-task execution, built on herdr's native
+worktree + agent-status support. Terminal-native counterpart of `cmux-team`.
+
+```
+Master（this session — user interaction, task creation）
+  └── Manager（idle-wait loop, task detection → Conductor spawn）
+        └── Conductor（herdr worktree isolation, autonomous execution）
+              └── Agent（actual work: impl, test, research, etc.）
+```
+
+## Architecture Overview
+
+| Layer | Role | Lifecycle | Communication |
+|-------|------|-----------|---------------|
+| **Master** | Decomposes goal into task files | This session | Writes `.herdr-team/tasks/*.md` |
+| **Manager** | Daemon: polls tasks, spawns Conductors | Long-running herdr workspace | Reads task dir, writes status |
+| **Conductor** | Per-task: worktree + Agent + result collection | Spawned by Manager, exits on completion | Reads task file, writes result |
+| **Agent** | Claude Code in a worktree workspace | Spawned by Conductor | Reads prompt from Conductor |
+
+## Why herdr fits this well
+
+- `herdr worktree create --branch … --base …` makes the branch **and** its workspace in
+  one call — Conductor isolation is one command.
+- Per-pane `agent_status` + `herdr wait agent-status --status idle` gives reliable
+  completion detection (no screen-scraping for prompts).
+
+## Your Task
+
+1. **Initialize** — create `.herdr-team/` structure.
+2. **Decompose** — break the goal into discrete, independent task files.
+3. **Launch Manager** — spawn the Manager in a dedicated herdr workspace.
+4. **Monitor** — report progress as tasks complete.
+
+### Decomposition Rules
+
+- **Independent**: parallel worktrees must never touch the same files. If they would,
+  merge into one task.
+- **Self-contained**: each task file is executable by an agent with NO access to this
+  conversation — include all paths, constraints, and decisions in the body.
+- **Verifiable**: every task has Acceptance Criteria as checkable statements (commands,
+  expected behavior).
+- **Right-sized**: one task = one PR-sized change.
+
+## Quick Start
+
+### 1. Initialize
+
+```bash
+mkdir -p .herdr-team/tasks .herdr-team/results .herdr-team/logs
+```
+
+### 2. Create Task Files
+
+```bash
+cat > .herdr-team/tasks/001-implement-auth.md << 'TASK'
+---
+id: "001"
+name: implement-auth
+status: pending
+branch: team/001-implement-auth
+---
+
+Implement JWT authentication middleware.
+
+## Acceptance Criteria
+- Middleware validates JWT tokens
+- Returns 401 on invalid/expired tokens
+- Passes user context to downstream handlers
+TASK
+```
+
+### 3. Launch Manager
+
+```bash
+CREATE=$(herdr workspace create --label team-manager --no-focus)
+WS=$(echo "$CREATE" | jq -r '.result.workspace.workspace_id')
+P=$(echo  "$CREATE" | jq -r '.result.root_pane.pane_id')
+herdr pane run "$P" "claude --dangerously-skip-permissions"
+herdr wait output "$P" --match '(❯|>|Claude Code)' --regex --timeout 30000
+
+herdr pane send-text "$P" "$(cat <<'PROMPT'
+You are the Manager in a herdr-team hierarchy.
+
+## Your Loop
+1. Poll .herdr-team/tasks/ every 10s for files with status: pending
+2. For each pending task:
+   a. Update status to "running"
+   b. Run: bash .herdr-team/conductor.sh <task-file>
+3. When the conductor exits, check .herdr-team/results/<task-id>.md
+4. Update task status to "done" or "failed"
+5. Continue until no pending tasks remain
+6. Write a summary to .herdr-team/results/summary.md
+
+## Rules
+- Max 3 concurrent Conductors
+- On Conductor failure, mark task "failed" and continue
+- Log all actions to .herdr-team/logs/manager.log
+PROMPT
+)"
+herdr pane send-keys "$P" Enter
+```
+
+### 4. Monitor Progress
+
+```bash
+for f in .herdr-team/tasks/*.md; do
+  echo "$(basename "$f"): $(grep '^status:' "$f" | cut -d' ' -f2)"
+done
+cat .herdr-team/results/summary.md
+tail -20 .herdr-team/logs/manager.log
+```
+
+## Conductor Script
+
+See @references/conductor.md for the full script. Core flow (herdr worktree does the
+isolation in one call):
+
+```bash
+# .herdr-team/conductor.sh <task-file>
+TASK_FILE="$1"
+TASK_ID=$(grep '^id:'     "$TASK_FILE" | tr -d '"' | awk '{print $2}')
+BRANCH=$( grep '^branch:'  "$TASK_FILE" | awk '{print $2}')
+
+# 1. Create worktree + its workspace in one shot
+CREATE=$(herdr worktree create --branch "$BRANCH" --base main --label "agent-$TASK_ID" --no-focus)
+WS=$(echo "$CREATE" | jq -r '.result.workspace.workspace_id // .result.workspace_id')
+P=$( echo "$CREATE" | jq -r '.result.root_pane.pane_id // .result.pane.pane_id')
+
+# 2. Launch the Agent
+herdr pane run "$P" "claude --dangerously-skip-permissions"
+herdr wait output "$P" --match '(❯|>|Claude Code)' --regex --timeout 30000
+
+# 3. Send the task body as the prompt
+PROMPT=$(sed '1,/^---$/d; /^---$/d' "$TASK_FILE")
+herdr pane send-text "$P" "$PROMPT"
+herdr pane send-keys "$P" Enter
+
+# 4. Wait for completion, then collect results
+herdr wait agent-status "$P" --status idle --timeout 1800000
+herdr pane read "$P" --source recent --lines 500 > ".herdr-team/results/${TASK_ID}.md"
+
+# 5. Cleanup
+herdr workspace close "$WS"
+```
+
+## Communication Protocol
+
+Pull-based, file-driven — no push notifications needed.
+
+```
+.herdr-team/
+├── tasks/            # Master writes, Manager reads (pending → running → done/failed)
+├── results/          # Conductor writes, Master reads (+ summary.md)
+├── logs/             # All layers append
+└── (worktrees managed by herdr; list with: herdr worktree list)
+```
+
+## Error Handling
+
+- **Manager crash**: relaunch — it resumes from task file statuses (idempotent).
+- **Conductor timeout**: `herdr wait agent-status` returns non-zero after `--timeout`;
+  mark the task "failed" and close the workspace.
+- **Agent blocked**: read the pane, send the required input via `pane send-text` + `Enter`.
+- **Worktree conflict**: `herdr worktree create` errors → skip task, mark "failed".
+- **herdr not found**: abort with installation instructions.
+
+## Cleanup
+
+```bash
+# Close team workspaces
+herdr workspace list | jq -r '.result.workspaces[] | select(.label|test("team-manager|^agent-")) | .workspace_id' \
+  | xargs -I{} herdr workspace close {}
+
+# Remove team worktrees (herdr-created)
+herdr worktree list | jq -r '.result.worktrees[] | select(.branch|test("^team/")) | .open_workspace_id // empty' \
+  | xargs -I{} herdr worktree remove --workspace {} --force
+
+# Remove state directory
+rm -rf .herdr-team/
+```
+
+## Related Skills
+
+| Skill | When to Use |
+|-------|-------------|
+| [../herdr-agent/SKILL.md](../herdr-agent/SKILL.md) | Single sub-agent spawn (simpler, no hierarchy) |
+| [../herdr-core/SKILL.md](../herdr-core/SKILL.md) | Core topology + worktree control |
+| [../herdr-fork/SKILL.md](../herdr-fork/SKILL.md) | Fork the current session (interactive) |
+| [../cmux-team/SKILL.md](../cmux-team/SKILL.md) | Same role, but for the cmux GUI app |

--- a/.claude/skills/herdr-team/references/conductor.md
+++ b/.claude/skills/herdr-team/references/conductor.md
@@ -1,0 +1,114 @@
+# Conductor Script
+
+Full conductor script for `.herdr-team/conductor.sh`.
+
+## Script
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+TASK_FILE="$1"
+TASK_ID=$(grep '^id:'      "$TASK_FILE" | tr -d '"' | awk '{print $2}')
+TASK_NAME=$(grep '^name:'   "$TASK_FILE" | awk '{print $2}')
+BRANCH=$( grep '^branch:'    "$TASK_FILE" | awk '{print $2}')
+TIMEOUT_MIN=$(grep '^timeout_min:' "$TASK_FILE" | awk '{print $2}')
+TIMEOUT_MIN="${TIMEOUT_MIN:-30}"
+TIMEOUT_MS=$((TIMEOUT_MIN * 60 * 1000))
+
+LOG=".herdr-team/logs/conductor-${TASK_ID}.log"
+RESULT_FILE=".herdr-team/results/${TASK_ID}.md"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >> "$LOG"; }
+
+log "Starting conductor for task $TASK_ID ($TASK_NAME)"
+
+# --- 1. Update task status ---
+sed -i '' "s/^status: pending/status: running/" "$TASK_FILE"
+log "Status → running"
+
+# --- 2. Create worktree + its workspace (herdr does both in one call) ---
+BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo "main")
+
+CREATE=$(herdr worktree create --branch "$BRANCH" --base "$BASE_BRANCH" --label "agent-$TASK_ID" --no-focus 2>>"$LOG") || {
+  log "ERROR: Failed to create worktree/workspace"
+  sed -i '' "s/^status: running/status: failed/" "$TASK_FILE"
+  printf '# Task %s: FAILED\n\nFailed to create worktree for branch %s\n' "$TASK_ID" "$BRANCH" > "$RESULT_FILE"
+  exit 1
+}
+WS=$(echo "$CREATE" | jq -r '.result.workspace.workspace_id // .result.workspace_id')
+P=$( echo "$CREATE" | jq -r '.result.root_pane.pane_id // .result.pane.pane_id')
+log "Worktree workspace $WS, pane $P"
+
+# --- 3. Launch the Agent ---
+herdr pane run "$P" "claude --dangerously-skip-permissions"
+
+# --- 4. Wait for Claude to be ready ---
+if ! herdr wait output "$P" --match '(❯|>|Claude Code)' --regex --timeout 30000 >>"$LOG" 2>&1; then
+  log "ERROR: Claude not ready within 30s"
+  sed -i '' "s/^status: running/status: failed/" "$TASK_FILE"
+  printf '# Task %s: FAILED\n\nClaude Code did not start within 30s\n' "$TASK_ID" > "$RESULT_FILE"
+  herdr workspace close "$WS"
+  exit 1
+fi
+log "Claude ready"
+
+# --- 5. Send task prompt (body after the second ---) ---
+PROMPT=$(awk 'BEGIN{c=0} /^---$/{c++; next} c>=2{print}' "$TASK_FILE")
+
+herdr pane send-text "$P" "$(cat <<AGENT_PROMPT
+You are an Agent in a herdr-team hierarchy. Work autonomously.
+
+## Task
+${PROMPT}
+
+## Rules
+- Work only in this directory (git worktree)
+- Commit your changes with descriptive messages
+- Do not push — the Master will handle PR creation
+- When done, exit cleanly
+AGENT_PROMPT
+)"
+herdr pane send-keys "$P" Enter
+log "Prompt sent"
+
+# --- 6. Wait for completion (native agent-status, with timeout) ---
+if ! herdr wait agent-status "$P" --status idle --timeout "$TIMEOUT_MS" >>"$LOG" 2>&1; then
+  log "TIMEOUT after ${TIMEOUT_MIN}min"
+  sed -i '' "s/^status: running/status: failed/" "$TASK_FILE"
+  herdr pane read "$P" --source recent --lines 500 > "$RESULT_FILE"
+  printf '\n\n---\n**TIMEOUT** after %s minutes\n' "$TIMEOUT_MIN" >> "$RESULT_FILE"
+  herdr workspace close "$WS"
+  exit 1
+fi
+
+# --- 7. Collect results ---
+herdr pane read "$P" --source recent --lines 500 > "$RESULT_FILE"
+log "Results collected to $RESULT_FILE"
+
+# --- 8. Update status ---
+sed -i '' "s/^status: running/status: done/" "$TASK_FILE"
+log "Status → done"
+
+# --- 9. Cleanup workspace (worktree kept for review) ---
+herdr workspace close "$WS"
+log "Workspace closed. Worktree preserved (herdr worktree list)."
+```
+
+## Usage
+
+```bash
+bash .herdr-team/conductor.sh .herdr-team/tasks/001-implement-auth.md
+```
+
+## Notes
+
+- herdr's `worktree create` makes the branch **and** its workspace in one call, so there is
+  no separate `git worktree add` step (contrast with cmux-team).
+- Completion is detected via native per-pane `agent_status` (`herdr wait agent-status
+  --status idle`), not by screen-scraping for a shell prompt — more reliable.
+- The worktree is preserved after completion so the Master can review and create PRs; remove
+  it later with `herdr worktree remove --workspace <ID> --force`.
+- `sed -i ''` is macOS-compatible; on Linux use `sed -i`.
+- Timeout is per-task via the task file's `timeout_min` field (default 30).
+- Logs are per-conductor at `.herdr-team/logs/conductor-<id>.log`.

--- a/.zshrc
+++ b/.zshrc
@@ -933,6 +933,10 @@ if [ $commands[stern] ]; then
   source <(stern --completion=zsh)
 fi
 
+if [ $commands[herdr] ]; then
+  source <(herdr completion zsh)
+fi
+
 if [ $commands[aws] ]; then
   PATH=$HOME/.anyenv/envs/pyenv/shims/aws_completer:$PATH
 fi


### PR DESCRIPTION
## 概要

herdr（ターミナルネイティブなワークスペースマネージャー）の互換スキルをコア4つ追加。既存の `cmux-*` スキル群と1:1対応させ、`CMUX_WORKSPACE_ID` 未設定かつ herdr サーバ稼働時に使い分ける。

## 追加スキル

| herdr | cmux 相当 | 役割 |
|-------|-----------|------|
| `herdr-core` | `cmux` | workspace/tab/pane/worktree のトポロジ制御 |
| `herdr-agent` | `cmux-agent` | headless サブエージェント起動 |
| `herdr-fork` | `cmux-fork` | `--continue --fork-session` を split pane で |
| `herdr-team` | `cmux-team` | 4層マルチエージェントオーケストレーション |

## cmux 版からの改善

- 完了検知: 画面 grep ではなく `herdr wait agent-status --status idle`（per-pane の agent_status をネイティブ追跡）
- worktree: `herdr worktree create --branch … --base …` でブランチと workspace を一括生成

## その他

- `.claude/CLAUDE.md` に herdr Integration 節（使い分け・対応表・CLI要点）
- `.zshrc` に zsh 補完
- `cmux-browser`/`cmux-markdown` は herdr がターミナル専用のため対象外（browser は claude-in-chrome MCP で代替する旨を注記）

## 対象外（別管理）

- `.claude/settings.json` の herdr フック・`herdr-agent-state.sh` は herdr が自動生成する managed file のため本 PR には含めない

https://claude.ai/code/session_017jaq12iYkBWbKqMCVrYJmt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documented workflows for managing herdr workspaces, panes, tabs, worktrees, and terminal commands.
  * Added guidance for launching individual or multiple headless agents, including status monitoring and result collection.
  * Added support for forking Claude sessions into new herdr panes.
  * Added a structured multi-agent team workflow with task tracking, logging, cleanup, and result reporting.
  * Added Zsh autocompletion for the herdr command.

* **Documentation**
  * Added guidance for choosing herdr or cmux and troubleshooting common herdr issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->