### PR TITLE
feat(skills): add iterm2 cmux-compatible topology control skill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -171,3 +171,26 @@ cmux identify --json &>/dev/null
 - socket API 系サブコマンドは `{"id":..,"result":{..}}` 形状の JSON を返す。`jq` で `.result` 配下を参照
 - エージェント完了検知は画面 grep ではなく **`herdr wait agent-status <pane> --status idle`**（per-pane の agent_status をネイティブ追跡）が信頼できる
 - worktree は `herdr worktree create --branch … --base …` でブランチと workspace を一括生成
+
+## iTerm2 (plain) Integration
+
+cmux も herdr も使わない**素の iTerm2** セッションでは、`iterm2` スキルで cmux 互換のペイン操作を行う。バックエンドは `it2` CLI（iTerm2 Python API ラッパー）。
+
+### 判定と使い分け
+
+- `$CMUX_WORKSPACE_ID` あり → **cmux 系スキル**を優先
+- cmux 外で `herdr status server` が running → **herdr 系スキル**
+- どちらでもない素の iTerm2（`$TERM_PROGRAM=iTerm.app`）→ **`iterm2` スキル**
+
+### 前提（初回のみ）
+
+1. iTerm2 > Settings > General > Magic > **Enable Python API** を有効化
+2. `it2` 導入: `uv tool install it2`
+3. **Automation 権限の承認**: `it2 session list` を一度実行し、ダイアログを許可（cookie 取得のため）。確実な代替は iTerm2 の Scripts メニュー経由起動（`ITERM2_COOKIE` 自動注入）
+4. 診断: `bash ~/.claude/skills/iterm2/scripts/it2-doctor.sh`（OK/NG と修復手順を出力）
+
+### 要点
+
+- cmux 概念との対応: Window=ウィンドウ / Workspace=タブ / Pane・Surface=session（分割ペイン）
+- 現 session ID は `${ITERM_SESSION_ID##*:}` で取得（列挙不要）
+- ブラウザ自動化は iTerm2 組み込みブラウザではなく **claude-in-chrome** を使う（WKWebView は外部制御口がなく、ネットワーク傍受も不可のため）

--- a/.claude/skills/iterm2/SKILL.md
+++ b/.claude/skills/iterm2/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: iterm2
+description: >-
+  Control iTerm2 topology and routing from the CLI — windows, tabs, split panes
+  (sessions), focus, splits, send/run text, read/capture screen, and attention
+  flash — via the `it2` wrapper over the iTerm2 Python API. cmux-compatible
+  command vocabulary for the plain iTerm2 environment (cmux 外). Use when user
+  says "split pane", "new tab", "focus session", "send to pane", "read screen",
+  "iTermのペイン操作", "レイアウト変更", or needs deterministic placement in a
+  multi-pane iTerm2 layout without cmux.
+allowed-tools: Bash
+---
+
+# iTerm2 Core Control (cmux-compatible)
+
+素の iTerm2（cmux 外）で、cmux と同じ語彙でトポロジ操作を行うためのスキル。
+バックエンドは `it2` CLI（iTerm2 Python API のラッパー）。
+
+**使い分け:** cmux 内（`$CMUX_WORKSPACE_ID` あり）なら `cmux` スキルを優先。
+herdr 内なら `herdr-core`。どちらでもない素の iTerm2 でのみ本スキルを使う。
+
+## Prerequisites（初回のみ）
+
+使う前に必ず診断を実行し、[NG] があれば先に解消する。スクリプトはこの SKILL.md と
+同じディレクトリの `scripts/it2-doctor.sh`（配備先は `~/.claude/skills/iterm2/scripts/`）:
+
+```bash
+bash ~/.claude/skills/iterm2/scripts/it2-doctor.sh
+```
+
+診断が確認する前提:
+1. iTerm2 内で実行中（`$ITERM_SESSION_ID` あり）
+2. `it2` CLI 導入済み（無ければ `uv tool install it2`）
+3. iTerm2 Settings > General > Magic > **Enable Python API** が有効
+4. **Automation 権限 / cookie**: 初回は `it2` を手で1回実行し、表示される
+   「control iTerm2」ダイアログと Automation 許可を承認する。確実な代替は
+   iTerm2 の Scripts メニュー経由起動（`ITERM2_COOKIE` が自動注入される）。
+
+接続不能時は原因の 9 割がこの Automation 権限。**診断スクリプトの指示に従う**こと。
+
+## Core Concepts（cmux との対応）
+
+| cmux 概念 | iTerm2 の実体 | it2 での扱い |
+|-----------|---------------|--------------|
+| Window    | macOS ウィンドウ | `it2 window` |
+| Workspace | タブ            | `it2 tab` |
+| Pane / Surface | 分割された session | `it2 session` |
+
+iTerm2 には cmux の Pane/Surface の二層区別が無く、**分割ペイン = session** の一層。
+
+## Fast Start
+
+```bash
+# --- identify: 現在の呼び出しコンテキスト（cmux identify 相当） ---
+echo "$ITERM_SESSION_ID"            # 形式: wNtNpN:UUID
+echo "${ITERM_SESSION_ID##*:}"      # UUID 部分（session の一意 ID）
+
+# --- list: トポロジ列挙 ---
+it2 window list                     # cmux list-windows
+it2 tab list                        # cmux list-workspaces
+it2 session list                    # cmux list-panes
+
+# --- create: 生成 ---
+it2 tab new                         # cmux new-workspace
+it2 window new                      # 新規ウィンドウ
+it2 session split --vertical        # 右に分割（cmux new-split right）
+it2 session split                   # 下に分割（cmux new-split down）
+
+# --- focus/route: フォーカス移動 ---
+it2 session focus <session-id>      # cmux focus surface
+it2 tab select <index|id>           # タブ選択
+it2 tab goto <index>                # インデックスでタブへ
+it2 window focus <window-id>
+
+# --- send/run: ペインへ入力 ---
+it2 session send "text"             # 改行なし送信
+it2 session run  "cmd"              # 改行付き実行（コマンド投入）
+it2 session run "ls -la" --all      # 全 session に一括
+
+# --- read/capture: 画面取得 ---
+it2 session read                    # 画面テキスト取得（cmux read 相当）
+it2 session capture -o /tmp/pane.png   # スクリーンショット保存（-o は必須）
+
+# --- attention: 注意喚起（cmux trigger-flash 相当・依存ゼロ） ---
+printf '\033]1337;RequestAttention=fireworks\a'   # 現在ペインをフラッシュ
+# 別 session をフラッシュ: それを標的に上記エスケープを送る
+it2 session send $'\033]1337;RequestAttention=fireworks\a' --session <id>
+
+# --- move/close ---
+it2 tab move                        # タブを新規ウィンドウへ分離
+it2 session close                   # session を閉じる
+it2 tab close ; it2 window close
+
+# --- monitor: イベント購読 ---
+it2 monitor activity                # session アクティビティ
+it2 monitor output                  # 出力
+it2 monitor prompt                  # シェルプロンプト（shell integration 要）
+```
+
+## Handle Model
+
+- `it2 session list` / `tab list` / `window list` が ID を返す。以降の
+  `focus`/`close`/`select` にはその ID か index を渡す。
+- 現在 session の ID は環境変数 `${ITERM_SESSION_ID##*:}` で取れる（列挙不要）。
+
+## 機能ギャップ（cmux との差分）
+
+| cmux 機能 | iTerm2 での状況 |
+|-----------|-----------------|
+| `reorder-surface`（任意順の並べ替え） | tab は `goto/select/next/prev` のみ。任意位置への差し込みは非対応 |
+| Surface 単位のブラウザ webview | 非対応。ブラウザ自動化は `claude-in-chrome` を使う |
+| ネットワーク傍受 | iTerm2 側に手段なし（`claude-in-chrome` / Chromium 側で行う） |
+
+## Error Handling
+
+- `it2` が見つからない → `uv tool install it2` を案内（uv 前提。無ければ `pipx install it2`）。
+- `Not running inside iTerm2 or Python API not enabled` → まず `scripts/it2-doctor.sh` を実行。
+  多くは Automation 権限未許可。診断の修復手順に従う。
+- ID 参照が無効 → `it2 session list` / `it2 window list` で有効な ID を再取得。
+- 破壊的操作（`session close` / `tab close` / `window close`）は対象 ID を明示し、
+  実行前に対象を `it2 session read` 等で確認してから行う。
+
+## Related Skills
+
+| Skill | When to Use |
+|-------|-------------|
+| [../cmux/SKILL.md](../cmux/SKILL.md) | cmux 内（`$CMUX_WORKSPACE_ID` あり）でのトポロジ制御 |
+| [../herdr-core/SKILL.md](../herdr-core/SKILL.md) | herdr（TUI/ヘッドレス/リモート）でのトポロジ制御 |
+| claude-in-chrome (MCP) | ブラウザ自動化（DOM/ネットワーク/コンソール）。iTerm2 組み込みブラウザは制御不可 |

--- a/.claude/skills/iterm2/scripts/it2-doctor.sh
+++ b/.claude/skills/iterm2/scripts/it2-doctor.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# it2-doctor: iTerm2 cmux互換スキルの前提を決定的に診断する。
+# 各チェックを OK/NG で出力し、NG には具体的な修復手順を添える。
+# 終了コード: 0=全チェック通過, 1=ブロッキングな問題あり。
+set -uo pipefail
+
+ok()   { printf '  [OK] %s\n' "$1"; }
+ng()   { printf '  [NG] %s\n' "$1"; BLOCK=1; }
+info() { printf '       %s\n' "$1"; }
+
+BLOCK=0
+IT2="$(command -v it2 || echo "$HOME/.local/bin/it2")"
+
+echo "== it2-doctor: iTerm2 Python API 前提診断 =="
+
+# 1. iTerm2 内で実行されているか
+if [ "${TERM_PROGRAM:-}" = "iTerm.app" ] || [ -n "${ITERM_SESSION_ID:-}" ]; then
+  ok "iTerm2 内で実行中 (ITERM_SESSION_ID=${ITERM_SESSION_ID:-?})"
+else
+  ng "iTerm2 内で実行されていない (TERM_PROGRAM=${TERM_PROGRAM:-unset})"
+  info "iTerm2 のターミナルから起動し直してください。"
+fi
+
+# 2. it2 CLI の有無
+if [ -x "$IT2" ]; then
+  ok "it2 CLI: $IT2 ($($IT2 --version 2>/dev/null))"
+else
+  ng "it2 CLI が見つからない"
+  info "インストール: uv tool install it2   (または pipx install it2)"
+fi
+
+# 3. Python API サーバが有効か
+if [ "$(defaults read com.googlecode.iterm2 EnableAPIServer 2>/dev/null)" = "1" ]; then
+  ok "Enable Python API 設定 = 有効"
+else
+  ng "Enable Python API が無効"
+  info "iTerm2 > Settings > General > Magic > 'Enable Python API' をオンにする。"
+fi
+
+# 4. 実接続テスト（Automation 権限 / cookie の最終確認）
+if [ -x "$IT2" ]; then
+  OUT="$(timeout 20 "$IT2" session list 2>&1)"
+  if printf '%s' "$OUT" | grep -qiE 'not running inside|not enabled|connection error'; then
+    ng "it2 が iTerm2 に接続できない (Automation 権限 / cookie 未取得)"
+    info "初回のみ次の許可が必要:"
+    info "  1) it2 を一度手で実行し、表示される 2つのダイアログを許可する"
+    info "     ('X wants to control iTerm2' と Automation の許可)"
+    info "  2) それでも失敗する場合: System Settings > Privacy & Security >"
+    info "     Automation で、ターミナル/claude が iTerm2 を制御するのを許可"
+    info "  3) 代替: iTerm2 の Scripts メニュー経由なら ITERM2_COOKIE が注入され確実"
+    info "  --- it2 の生出力 ---"
+    printf '%s\n' "$OUT" | sed 's/^/       | /'
+  else
+    ok "it2 → iTerm2 接続 OK (session list 応答あり)"
+  fi
+fi
+
+echo
+if [ "$BLOCK" -eq 0 ]; then
+  echo "== 結果: 全チェック通過。iterm2 スキルを使用可能 =="
+  exit 0
+else
+  echo "== 結果: 上記 [NG] を解消してください =="
+  exit 1
+fi


### PR DESCRIPTION
## 概要

素の iTerm2（cmux/herdr を使わない環境）で、**cmux 互換の語彙**でペイン/タブ/ウィンドウ操作を行う `iterm2` スキルを追加。バックエンドは既存の `it2` CLI（iTerm2 Python API ラッパー）。

## 追加物

- `.claude/skills/iterm2/SKILL.md` — cmux→it2 マッピング、決定表、機能ギャップ、安全手順、Prerequisites
- `.claude/skills/iterm2/scripts/it2-doctor.sh` — 前提（iTerm2内 / it2 導入 / Python API 有効 / Automation 権限）を OK/NG で決定的に診断し修復手順を出力
- `.claude/CLAUDE.md` — 「iTerm2 (plain) Integration」セクションを追記（cmux/herdr との使い分け）

## cmux → iTerm2 対応（要点）

| cmux | iTerm2 skill |
|---|---|
| identify | `${ITERM_SESSION_ID##*:}` |
| list-windows/workspaces/panes | `it2 window/tab/session list` |
| new-workspace / new-split | `it2 tab new` / `it2 session split [-v]` |
| focus / send / read / capture | `it2 session focus/send/read/capture` |
| trigger-flash | `printf '\033]1337;RequestAttention=fireworks\a'`（依存ゼロ） |

## 検証

- SKILL.md の全コマンド/フラグを実物の `it2` v0.2.3 で裏取り済み
- `it2-doctor.sh` 実行で前提を確認（現状 Automation 権限のみ初回承認待ち）

## 既知の前提（利用者の初回操作）

`it2` の iTerm2 接続には Automation 権限の一度きりの承認が必要（`it2 session list` を1回実行して許可、または iTerm2 Scripts メニュー経由）。診断スクリプトが未承認時に手順を案内する。

## 機能ギャップ

任意順 reorder / ブラウザ webview / ネットワーク傍受は非対応。ブラウザ自動化は claude-in-chrome を使用（SKILL.md に明記）。

https://claude.ai/code/session_01Qgr4XkaSXFNrWeQRJxiHsj