### PR TITLE
fix(skills): correct iterm2 skill setup diagnosis

### DIFF
--- a/.claude/skills/iterm2/SKILL.md
+++ b/.claude/skills/iterm2/SKILL.md
@@ -30,13 +30,19 @@ bash ~/.claude/skills/iterm2/scripts/it2-doctor.sh
 
 診断が確認する前提:
 1. iTerm2 内で実行中（`$ITERM_SESSION_ID` あり）
-2. `it2` CLI 導入済み（無ければ `uv tool install it2`）
-3. iTerm2 Settings > General > Magic > **Enable Python API** が有効
-4. **Automation 権限 / cookie**: 初回は `it2` を手で1回実行し、表示される
-   「control iTerm2」ダイアログと Automation 許可を承認する。確実な代替は
-   iTerm2 の Scripts メニュー経由起動（`ITERM2_COOKIE` が自動注入される）。
+2. `it2` CLI を **websockets を <11 に固定**して導入する。既定の 16.x は同梱の
+   iterm2 2.20 と非互換で接続時に `RecursionError` になる:
+   ```bash
+   uv tool install --force it2 --with 'websockets<11'
+   ```
+3. iTerm2 Settings > General > Magic > **Enable Python API** を有効化し、
+   **iTerm2 を再起動**（設定反映に再起動が要る）
+4. 初回接続時に iTerm2 が API クライアント接続の許可ダイアログを出したら **Allow**。
+   cookie / Automation 権限は自動取得されるため、通常ここは問題にならない。
 
-接続不能時は原因の 9 割がこの Automation 権限。**診断スクリプトの指示に従う**こと。
+接続不能（`no close frame` / `RecursionError` / `not enabled`）の切り分けは、
+**2（websockets ピン）→ 3（API 有効化 + 再起動）→ 4（接続許可）** の順。
+`scripts/it2-doctor.sh` がこの順で診断する。
 
 ## Core Concepts（cmux との対応）
 

--- a/.claude/skills/iterm2/scripts/it2-doctor.sh
+++ b/.claude/skills/iterm2/scripts/it2-doctor.sh
@@ -37,19 +37,32 @@ else
   info "iTerm2 > Settings > General > Magic > 'Enable Python API' をオンにする。"
 fi
 
-# 4. 実接続テスト（Automation 権限 / cookie の最終確認）
+# 4. it2 の websockets バージョン（>=11 は iterm2 2.20 と非互換で RecursionError）
+IT2_PY="$HOME/.local/share/uv/tools/it2/bin/python"
+WS_VER="$("$IT2_PY" -c 'import importlib.metadata as m; print(m.version("websockets"))' 2>/dev/null)"
+if [ -n "$WS_VER" ]; then
+  if [ "${WS_VER%%.*}" -lt 11 ] 2>/dev/null; then
+    ok "it2 の websockets = $WS_VER (<11, 互換)"
+  else
+    ng "it2 の websockets = $WS_VER (>=11 は RecursionError で接続不可)"
+    info "再インストールで <11 に固定:"
+    info "  uv tool install --force it2 --with 'websockets<11'"
+  fi
+else
+  info "it2 の websockets バージョン未取得（uv tool 以外の導入かも）"
+fi
+
+# 5. 実接続テスト
 if [ -x "$IT2" ]; then
   OUT="$(timeout 20 "$IT2" session list 2>&1)"
-  if printf '%s' "$OUT" | grep -qiE 'not running inside|not enabled|connection error'; then
-    ng "it2 が iTerm2 に接続できない (Automation 権限 / cookie 未取得)"
-    info "初回のみ次の許可が必要:"
-    info "  1) it2 を一度手で実行し、表示される 2つのダイアログを許可する"
-    info "     ('X wants to control iTerm2' と Automation の許可)"
-    info "  2) それでも失敗する場合: System Settings > Privacy & Security >"
-    info "     Automation で、ターミナル/claude が iTerm2 を制御するのを許可"
-    info "  3) 代替: iTerm2 の Scripts メニュー経由なら ITERM2_COOKIE が注入され確実"
-    info "  --- it2 の生出力 ---"
-    printf '%s\n' "$OUT" | sed 's/^/       | /'
+  if printf '%s' "$OUT" | grep -qiE 'not running inside|not enabled|connection error|no close frame|recursion'; then
+    ng "it2 が iTerm2 に接続できない"
+    info "確認順（この順で潰す）:"
+    info "  1) 上の websockets が <11 に固定されているか"
+    info "  2) Enable Python API をオンにした後、iTerm2 を再起動したか（設定反映に必要）"
+    info "  3) 初回接続時に iTerm2 が出す API クライアント許可ダイアログを Allow したか"
+    info "  --- it2 の生出力（末尾） ---"
+    printf '%s\n' "$OUT" | tail -3 | sed 's/^/       | /'
   else
     ok "it2 → iTerm2 接続 OK (session list 応答あり)"
   fi


### PR DESCRIPTION
## 概要

#97 で追加した `iterm2` スキルの前提診断を、実機検証で判明した正確なブロッカーに修正。

## 誤診断の訂正

当初 `it2-doctor.sh` は接続不能の原因を「Automation 権限」としていたが、実機で切り分けた結果それは誤りだった。実際のブロッカーは3層:

1. **websockets 非互換** — it2 の venv は既定で `websockets 16.0` が入り、同梱の `iterm2` 2.20 と非互換で接続時に `RecursionError`。→ `uv tool install --force it2 --with 'websockets<11'`（検証で 10.4 に固定して解消）
2. **iTerm2 再起動** — Enable Python API を有効化後、反映に iTerm2 の再起動が必要
3. **API クライアント接続許可** — 初回接続時のダイアログを Allow

（cookie / Automation 権限は osascript で正常取得でき、原因ではなかった）

## 変更

- `scripts/it2-doctor.sh`: websockets バージョンチェックを追加。接続失敗時の案内を「websockets ピン → 再起動 → 接続許可」の順に修正
- `SKILL.md`: Prerequisites を同内容に更新

## 検証

- `it2-doctor.sh` 実行で websockets = 10.4 (<11) が [OK] 表示、接続 NG は再起動待ちの正しい案内を出すことを確認

https://claude.ai/code/session_01Qgr4XkaSXFNrWeQRJxiHsj