### PR TITLE
docs: add Claude Code plugin marketplace setup and sync instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,56 @@ packages reappear if they are still installed. Review `git diff Brewfile`
 after running it, and use `brew uninstall` to remove unwanted packages from
 the system rather than only deleting their lines here.
 
+## Claude Code plugins
+
+Generic and personal skills live in two private plugin marketplaces instead
+of `.claude/skills/`:
+
+- [valbeat/claude-plugins](https://github.com/valbeat/claude-plugins) —
+  `writing`, `design`, `git-workflow`, `dev-workflow`, `skill-tools`
+- [valbeat/claude-plugins-private](https://github.com/valbeat/claude-plugins-private) —
+  `personal-tools`
+
+Skills are invoked with plugin namespaces (e.g. `/git-workflow:commit`,
+`/dev-workflow:spec`). Environment-coupled skills (cmux, herdr, iterm2,
+hunk-review, etc.) remain in `.claude/skills/` here.
+
+### Setup on a new machine
+
+Both marketplaces are private repos, so SSH access to GitHub (or `gh auth
+login`) must work first. Then:
+
+```shell
+$ cd $HOME/dotfiles && git pull   # syncs .claude/settings.json via symlink
+```
+
+`extraKnownMarketplaces` and `enabledPlugins` in `.claude/settings.json`
+declare everything; Claude Code picks them up on next launch. If plugins do
+not install automatically:
+
+```shell
+$ claude plugin marketplace add valbeat/claude-plugins
+$ claude plugin marketplace add valbeat/claude-plugins-private
+$ claude plugin install writing@valbeat-plugins        # repeat for the rest
+$ claude plugin list                                   # verify all 6 enabled
+```
+
+### Updating skills
+
+Edit skills in the marketplace clones
+(`~/src/github.com/valbeat/claude-plugins{,-private}`), not here. After
+pushing, sync each machine with:
+
+```shell
+$ claude plugin marketplace update
+$ claude plugin update
+```
+
+Plugins are versioned by commit SHA, so pushing is enough for `update` to
+pick up changes. Dotfiles-resident skills still sync via plain `git pull`.
+For background auto-update of the private marketplaces, set `GITHUB_TOKEN`
+in the environment; manual `marketplace update` needs no token.
+
 ## nix-darwin
 
 macOS system settings are managed declaratively with

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ## Installing
 
 ```shell
-$ git clone git@github.com:valbeat/dotfiles.git $HOME/dotfiles
-$ cd $HOME/dotfiles
-$ make install
+git clone git@github.com:valbeat/dotfiles.git $HOME/dotfiles
+cd $HOME/dotfiles
+make install
 ```
 This will create symlinks from this repo to your home folder.
 
@@ -14,13 +14,13 @@ This will create symlinks from this repo to your home folder.
 Install the packages declared in the `Brewfile`:
 
 ```shell
-$ make brew
+make brew
 ```
 
 After installing or removing packages, refresh the `Brewfile`:
 
 ```shell
-$ make brew-dump
+make brew-dump
 ```
 
 `brew-dump` regenerates the whole `Brewfile` from the current environment.
@@ -49,7 +49,7 @@ Both marketplaces are private repos, so SSH access to GitHub (or `gh auth
 login`) must work first. Then:
 
 ```shell
-$ cd $HOME/dotfiles && git pull   # syncs .claude/settings.json via symlink
+cd $HOME/dotfiles && git pull   # syncs .claude/settings.json via symlink
 ```
 
 `extraKnownMarketplaces` and `enabledPlugins` in `.claude/settings.json`
@@ -57,10 +57,10 @@ declare everything; Claude Code picks them up on next launch. If plugins do
 not install automatically:
 
 ```shell
-$ claude plugin marketplace add valbeat/claude-plugins
-$ claude plugin marketplace add valbeat/claude-plugins-private
-$ claude plugin install writing@valbeat-plugins        # repeat for the rest
-$ claude plugin list                                   # verify all 6 enabled
+claude plugin marketplace add valbeat/claude-plugins
+claude plugin marketplace add valbeat/claude-plugins-private
+claude plugin install writing@valbeat-plugins        # repeat for the rest
+claude plugin list                                   # verify all 6 enabled
 ```
 
 ### Updating skills
@@ -70,8 +70,8 @@ Edit skills in the marketplace clones
 pushing, sync each machine with:
 
 ```shell
-$ claude plugin marketplace update
-$ claude plugin update
+claude plugin marketplace update
+claude plugin update
 ```
 
 Plugins are versioned by commit SHA, so pushing is enough for `update` to
@@ -90,7 +90,7 @@ This host uses Determinate Nix, so nix-darwin's own Nix management is disabled
 Prerequisites: install Nix (flakes enabled), e.g. the Determinate Systems installer:
 
 ```shell
-$ /bin/sh -c "$(curl --proto '=https' --tlsv1.2 -sSfL https://install.determinate.systems/nix)" -- install
+/bin/sh -c "$(curl --proto '=https' --tlsv1.2 -sSfL https://install.determinate.systems/nix)" -- install
 ```
 
 The flake exposes one configuration per host under `darwinConfigurations` in
@@ -103,9 +103,9 @@ Activation must run as root. Bootstrap once with `nix run`, then use
 the `.` flake reference resolves):
 
 ```shell
-$ MY_HOST=$(scutil --get LocalHostName)
-$ sudo nix run nix-darwin -- switch --flake ".#$MY_HOST"
-$ sudo darwin-rebuild switch --flake ".#$MY_HOST"
+MY_HOST=$(scutil --get LocalHostName)
+sudo nix run nix-darwin -- switch --flake ".#$MY_HOST"
+sudo darwin-rebuild switch --flake ".#$MY_HOST"
 ```
 
 Roll back with `sudo darwin-rebuild --rollback`.


### PR DESCRIPTION
## Summary

PR #102 で導入したプラグインマーケットプレイス構成について、複数マシンでの同期手順を README に追記する。

- 新しいマシンでの初回セットアップ（SSH/gh 認証 → dotfiles pull → プラグイン自動/手動インストール）
- スキル更新時の同期フロー（marketplace repo に push → `claude plugin marketplace update` → `claude plugin update`）
- private マーケットプレイスの自動更新には `GITHUB_TOKEN` が必要な旨

## Note

同内容のコミットを誤ってマージ済みの `refactor/extract-skills-to-plugins` ブランチに push してリモートブランチを再作成してしまったため、main から切り直したこの PR に載せ替えた。再作成された `refactor/extract-skills-to-plugins` は不要なので削除してください。

https://claude.ai/code/session_014DJ8FWrP5kgDo1NVzchVMM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded setup instructions for Claude Code plugins and private marketplaces.
  * Added guidance for configuring marketplace and plugin settings on new machines.
  * Documented commands for updating marketplace clones and installed plugins.
  * Clarified automatic and manual update requirements for private marketplaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->