### PR TITLE
chore: disable session URL attribution in commits and PRs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,9 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "includeCoAuthoredBy": false,
+  "attribution": {
+    "sessionUrl": false
+  },
   "permissions": {
     "allow": [
       "Bash",


### PR DESCRIPTION
## Summary
- `attribution.sessionUrl: false` を settings.json に追加し、コミットの `Claude-Session:` トレーラーと PR 本文へのセッションリンクの自動付与を無効化
- 既存の `includeCoAuthoredBy: false` は Co-Authored-By 行のみの制御で、セッションリンクは `attribution.sessionUrl`（デフォルト true）が別途制御しているため

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Disabled session URL attribution in the application’s configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->