### PR TITLE
ci: add nix build dry-run check for PRs

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,0 +1,24 @@
+name: Nix Build Check
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: nix run .#build (dry-run)
+    # darwinConfigurations target aarch64-darwin; macos-latest runners are Apple Silicon.
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@v16
+
+      - name: Dry-run build
+        run: nix run .#build

--- a/flake.nix
+++ b/flake.nix
@@ -17,5 +17,21 @@
         system = "aarch64-darwin";
         modules = [ ./darwin/configuration.nix ];
       };
+
+      # `nix run .#build` — dry-run build of the darwin system without activating.
+      # Used by CI (.github/workflows/nix-build.yml) and as a local preflight check.
+      apps.aarch64-darwin.build =
+        let
+          pkgs = nixpkgs.legacyPackages.aarch64-darwin;
+        in
+        {
+          type = "app";
+          program = toString (
+            pkgs.writeShellScript "build-dry-run" ''
+              exec nix build --dry-run --no-link \
+                "${self}#darwinConfigurations.takumas-MacBook-Pro.system" "$@"
+            ''
+          );
+        };
     };
 }


### PR DESCRIPTION
## Summary
- `flake.nix` に `apps.aarch64-darwin.build` を追加。`nix run .#build` で darwin システムを `nix build --dry-run --no-link` により評価する（activate はしない）
- PR ごとに `nix run .#build` を実行する GitHub Actions workflow `.github/workflows/nix-build.yml` を追加
  - `runs-on: macos-latest`（Apple Silicon なので aarch64-darwin をそのまま評価可能）
  - Nix インストールは `DeterminateSystems/nix-installer-action@v16`
  - `concurrency` で同一 PR の古い実行をキャンセル、`permissions: contents: read` で最小権限

## Notes
- dry-run は評価＋ビルド計画の算出まで。パッケージの実ビルド失敗は検出しないが、nix-darwin 設定の評価エラー・module 設定ミスの検出には十分
- `nix run .#build` はローカルの事前チェックにもそのまま使える

## Verification
- ローカルで `nix run .#build` を実行し exit 0 を確認
- `actionlint` で workflow を検証し通過

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated macOS Apple Silicon build checks for pull requests.
  * Added a local build preflight command to validate Darwin system configurations without producing build artifacts.
  * Superseded checks are automatically canceled to reduce redundant runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->