### PR TITLE
feat(flake): add switch and update apps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,20 +18,37 @@
         modules = [ ./darwin/configuration.nix ];
       };
 
-      # `nix run .#build` — dry-run build of the darwin system without activating.
-      # Used by CI (.github/workflows/nix-build.yml) and as a local preflight check.
-      apps.aarch64-darwin.build =
+      apps.aarch64-darwin =
         let
           pkgs = nixpkgs.legacyPackages.aarch64-darwin;
+          app = name: script: {
+            type = "app";
+            program = toString (pkgs.writeShellScript name script);
+          };
         in
         {
-          type = "app";
-          program = toString (
-            pkgs.writeShellScript "build-dry-run" ''
-              exec nix build --dry-run --no-link \
-                "${self}#darwinConfigurations.takumas-MacBook-Pro.system" "$@"
-            ''
-          );
+          # `nix run .#build` — dry-run build of the darwin system without activating.
+          # Used by CI (.github/workflows/nix-build.yml) and as a local preflight check.
+          build = app "build-dry-run" ''
+            exec nix build --dry-run --no-link \
+              "${self}#darwinConfigurations.takumas-MacBook-Pro.system" "$@"
+          '';
+
+          # `nix run .#switch` — build and activate the darwin system for this host.
+          # Activation must run as root; the host name comes from LocalHostName so
+          # forks with their own darwinConfigurations entry can use it as-is.
+          switch = app "darwin-switch" ''
+            exec sudo darwin-rebuild switch \
+              --flake "${self}#$(scutil --get LocalHostName)" "$@"
+          '';
+
+          # `nix run .#update` — pull the latest main and sync submodules to their
+          # remote default branches (replaces `make update`). Run from the repo root.
+          update = app "repo-update" ''
+            set -euo pipefail
+            git pull origin main
+            git submodule update --init --remote
+          '';
         };
     };
 }


### PR DESCRIPTION
## Summary
Makefile 引退計画の Step 1/4。CI 用だった `apps` を日常操作まで拡張する。

- `nix run .#switch` — `sudo darwin-rebuild switch` のラッパー。ホスト名は `scutil --get LocalHostName` から取るので、fork 側は自分の `darwinConfigurations` エントリを足すだけでそのまま使える
- `nix run .#update` — `git pull origin main` + `git submodule update --init --remote`。`make update` の置き換え（旧ターゲットは存在しない `master` ブランチを pull していた）
- 共通の `app` ヘルパーで writeShellScript の重複を排除（`.#build` も同ヘルパーに揃えた）

## Stacked PRs
1. **← this** apps 追加
2. home-manager 導入（symlink 移行）
3. Brewfile → homebrew モジュール
4. Makefile 縮退 + ドキュメント更新

## Verification
- `nix run .#build` exit 0（dry-run 評価）
- `nix flake show` で build / switch / update の 3 app を確認