### PR TITLE
feat(darwin): manage dotfile symlinks with home-manager

### DIFF
--- a/darwin/home.nix
+++ b/darwin/home.nix
@@ -1,0 +1,46 @@
+# home-manager configuration: declarative replacement for `make deploy`.
+#
+# Every entry below becomes a symlink in $HOME that ultimately resolves to
+# this repository checkout (via mkOutOfStoreSymlink), so editing a dotfile
+# in the repo takes effect immediately — no rebuild needed. This matches the
+# `ln -sfnv` behavior the Makefile provided.
+{ config, ... }:
+let
+  # Absolute path to this repository checkout. Must match where the repo is
+  # cloned; forks cloned elsewhere should adjust this.
+  dotfilesDir = "${config.home.homeDirectory}/src/github.com/valbeat/dotfiles";
+
+  # Mirrors the Makefile's DOTFILES list: every `.??*` entry in the repo root
+  # except .DS_Store, .git, .gitmodules, and .github.
+  dotfiles = [
+    ".claude"
+    ".coderabbit.yaml"
+    ".codex"
+    ".config"
+    ".gemini"
+    ".gitconfig"
+    ".gitconfig.local" # machine-local override, intentionally untracked
+    ".gitconfig.osx"
+    ".gitignore"
+    ".gitignore_global"
+    ".gvimrc"
+    ".ideavimrc"
+    ".screenrc"
+    ".tigrc"
+    ".tmux.conf"
+    ".vim"
+    ".vimrc"
+    ".zshrc"
+  ];
+in
+{
+  home.file = builtins.listToAttrs (
+    map (name: {
+      inherit name;
+      value.source = config.lib.file.mkOutOfStoreSymlink "${dotfilesDir}/${name}";
+    }) dotfiles
+  );
+
+  # Used for backwards compatibility of stateful data. Bump only with care.
+  home.stateVersion = "25.05";
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785306346,
+        "narHash": "sha256-DScBkW0fOgpGPK2trNoX3ryLTlaC14+gglFo/BhGJ4g=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "e705714e918c3b11affcdd15db2cbe3a070420a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
@@ -39,6 +59,7 @@
     },
     "root": {
       "inputs": {
+        "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,17 +5,30 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     nix-darwin.url = "github:nix-darwin/nix-darwin/master";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
+    home-manager.url = "github:nix-community/home-manager";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =
-    { self, nixpkgs, nix-darwin }:
+    { self, nixpkgs, nix-darwin, home-manager }:
     {
       # One entry per host; the attribute name must match `scutil --get LocalHostName`.
       # Forks: add your own host here. For Intel, set `system = "x86_64-darwin"`
       # AND `nixpkgs.hostPlatform` in darwin/configuration.nix to match.
       darwinConfigurations."takumas-MacBook-Pro" = nix-darwin.lib.darwinSystem {
         system = "aarch64-darwin";
-        modules = [ ./darwin/configuration.nix ];
+        modules = [
+          ./darwin/configuration.nix
+          home-manager.darwinModules.home-manager
+          {
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+            # Files already in the way (e.g. symlinks made by `make deploy`)
+            # are renamed with this suffix instead of aborting activation.
+            home-manager.backupFileExtension = "hm-backup";
+            home-manager.users.takuma = import ./darwin/home.nix;
+          }
+        ];
       };
 
       apps.aarch64-darwin =


### PR DESCRIPTION
## Summary
Makefile 引退計画の Step 2/4。`make deploy`（`ln -sfnv`）を home-manager の `home.file` 宣言に置き換える。

- `darwin/home.nix` 新規追加。Makefile の DOTFILES 一覧（`.??*` から .DS_Store / .git / .gitmodules / .github を除外）をそのまま `home.file` 化
- **mkOutOfStoreSymlink を採用**: $HOME の symlink は最終的にリポジトリ実体を指すので、「repo を直接編集して即反映」という現行の運用は変わらない（store 取り込み型だと編集ごとに switch が必要になるため見送り）
- `home-manager.backupFileExtension = "hm-backup"`: 既存の make deploy 製 symlink が残っていても activation が中断せず、`*.hm-backup` に退避される
- `.gitconfig.local` は untracked（マシンローカル）だが現行 make deploy 同様 symlink 対象に含めた
- Makefile の deploy 系ターゲットは Step 4 まで残すため、移行期間中は併存可能

## Stacked PRs
1. #107 apps 追加
2. **← this** home-manager 導入
3. Brewfile → homebrew モジュール
4. Makefile 縮退 + ドキュメント更新

## Verification
- `nix flake lock` で home-manager input を追加（nixpkgs は follows）
- `nix run .#build` exit 0（home.nix 込みの評価が通ることを確認）

## 反映手順（マージ後）
`nix run .#switch` 実行で $HOME の symlink が home-manager 管理に切り替わる。既存 symlink は `*.hm-backup` に退避されるので、動作確認後に削除してよい。