### PR TITLE
feat(claude): add worktree-gc skill

### DIFF
--- a/.claude/skills/worktree-gc/SKILL.md
+++ b/.claude/skills/worktree-gc/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: worktree-gc
+description: >-
+  使い終わった git worktree を状態ベース（PR の state / 未コミット変更 / 未 push
+  コミット）で判定して掃除する。cmux-team / herdr-team / cmux-agent が作った
+  worktree の溜まりを解消する。Use when user says "worktree掃除", "worktree整理",
+  "worktree GC", "worktreeが溜まってる", "ディスクを空けたい", or when a session
+  notices many stale worktrees.
+allowed-tools: Bash
+argument-hint: "[--apply] [--size] [--json] [--merged-grace <日>] [--stale-open <日>] [--empty-grace <日>]"
+---
+
+# worktree GC
+
+並列エージェント（cmux-team / herdr-team / cmux-agent）を回すと worktree が溜まる。
+1 worktree あたり node_modules だけで 1.3GB 程度あり、放置すると数十 GB になる。
+このスキルは**状態を見て**掃除する。所有者や作成時刻ではなく、消して安全かどうかで決める。
+
+## 実行
+
+対象リポジトリの中で実行する。既定は dry-run で、何も削除しない。
+
+```bash
+node ~/.claude/skills/worktree-gc/scripts/worktree-gc.mjs            # 判定を表示
+node ~/.claude/skills/worktree-gc/scripts/worktree-gc.mjs --apply    # 実際に削除
+node ~/.claude/skills/worktree-gc/scripts/worktree-gc.mjs --size     # 容量も測る（数十秒）
+```
+
+**必ず dry-run を見せてからユーザーの承認を得て `--apply` すること。** 無断で削除しない。
+
+## 判定基準
+
+上から順に評価し、最初に一致した規則を適用する。
+
+| 優先 | 条件 | 動作 |
+|---|---|---|
+| 1 | メインのチェックアウト、または `locked` | 触らない |
+| 2 | 未コミット変更・未追跡ファイルあり | **削除しない**（人間に見せる） |
+| 3 | PR なし かつ 未 push の独自コミットあり | **削除しない** |
+| 4 | PR が OPEN、最終更新から 14 日未満 | 保持 |
+| 5 | PR が OPEN、最終更新から 14 日以上 | `node_modules` だけ削除 |
+| 6 | PR が MERGED / CLOSED から 3 日以上 | worktree 削除（MERGED ならブランチも） |
+| 7 | PR なし、基準ブランチからの独自コミット 0 | 1 日で worktree 削除 |
+
+閾値は `--merged-grace` / `--stale-open` / `--empty-grace` で変えられる。
+
+## 設計上の前提（変更するときはここを壊さないこと）
+
+- **「マージ済みか」を git の祖先判定で決めない。** squash / rebase merge ではブランチの
+  コミットが基準ブランチの祖先にならないため、マージ済みでも「未マージ」に見える。
+  PR の state（`gh pr list --head <branch> --state all`）を正とする。
+- **worktree の削除とブランチの削除を分ける。** worktree を消してもコミット済みの作業は
+  ブランチの ref に残り、失われるのは未コミットの変更だけ。ブランチを消すのは PR が
+  MERGED のときだけ。CLOSED（未マージ）は成果がどこにも無いのでブランチを残す。
+- **stash は消えない。** `refs/stash` は common dir にあり全 worktree で共有される。
+- **`git worktree remove` に `--force` を使わない。** git 自身の「汚れていたら消さない」に守らせる。
+- **ディレクトリの mtime を判定に使わない。** ビルド生成物で動く。最終コミット日時 /
+  PR 更新日時 / worktree 管理ファイル（`gitdir`・`HEAD`）の mtime の最も新しいものを見る。
+- **`index` の mtime は見ない。** `git status` が stat 情報を書き戻すため、様子を見るだけで
+  「今触った」に化け、放置された worktree が現役に見えてしまう。
+- **サイズは判定に使わない。** 表示専用なので既定では測らない（`du` が node_modules を
+  走査して worktree 1 個あたり数秒かかる）。
+
+## テスト
+
+判定基準は 31 個のテストで固定してある。基準を変えるときはテストから直す。
+
+```bash
+node --test ~/.claude/skills/worktree-gc/scripts/worktree-gc.test.mjs
+```
+
+## 限界
+
+- **登録されていない worktree ディレクトリは見えない。** `git worktree list` に出ないものは
+  対象外（metadata だけ prune されてファイルが残った残骸など）。手で確認する。
+- **ローカルブランチ単体の掃除はしない。** 消すのは worktree を持つブランチだけ。
+  worktree を持たない古いブランチは対象外。

--- a/.claude/skills/worktree-gc/scripts/worktree-gc.mjs
+++ b/.claude/skills/worktree-gc/scripts/worktree-gc.mjs
@@ -1,0 +1,522 @@
+#!/usr/bin/env node
+// 使い終わった git worktree を状態ベースで判定して掃除するツール。
+//
+// 背景: エージェントを並列で走らせると worktree が溜まる。1 worktree あたり
+// node_modules だけで 1.3GB あり、放置すると数十 GB を占める。
+//
+// 判定の設計:
+//   - 「マージ済みか」は git の祖先判定では決められない。squash / rebase merge だと
+//     ブランチのコミットが main の祖先にならないため。PR の state を正とする。
+//   - worktree の削除とブランチの削除を分ける。worktree を消してもコミット済みの
+//     作業はブランチの ref に残り、失われるのは未コミットの変更だけ。
+//   - stash は common dir で共有されるため worktree を消しても失われない。
+//   - ディレクトリの mtime はビルド生成物で動くので使わない。最終コミット日時 /
+//     PR の更新日時 / worktree 管理ファイルの mtime のうち最も新しいものを
+//     「最終アクティビティ」とする。管理ファイルを見るのは、古い main から生やした
+//     ばかりの worktree を「放置」と誤判定しないため。
+//
+// 対象リポジトリの中で実行する。基準ブランチは origin/HEAD から検出する。
+//
+// 使い方:
+//   node ~/.claude/skills/worktree-gc/scripts/worktree-gc.mjs           判定結果を表示（何も消さない）
+//   node ~/.claude/skills/worktree-gc/scripts/worktree-gc.mjs --apply   判定に従って実際に削除する
+//   オプション:
+//     --size          ディスク使用量も測る（du が node_modules を走査するので数十秒かかる）
+//     --json          機械可読な出力
+//     --merged-grace <日> / --stale-open <日> / --empty-grace <日>
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readdirSync, rmSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+export const DEFAULTS = {
+  /** PR が閉じてから worktree を消すまでの猶予 */
+  mergedGraceDays: 3,
+  /** OPEN な PR が何日更新されなければ node_modules を落とすか */
+  staleOpenDays: 14,
+  /** 独自コミットを持たない worktree を消すまでの猶予 */
+  emptyGraceDays: 1,
+}
+
+/** worktree のうち node_modules が占める概算比率（解放見込みの計算に使う） */
+const NODE_MODULES_RATIO = 0.93
+
+/**
+ * worktree の状態から処分を決める純粋関数。
+ * 上から順に評価し、最初に一致した規則を適用する。
+ *
+ * verdict:
+ *   keep   … 現役。触らない
+ *   hold   … 消して良いか機械には決められない。人間に見せる
+ *   slim   … node_modules だけ削除して木は残す
+ *   delete … worktree を削除する（deleteBranch が true ならブランチも）
+ */
+export const classifyWorktree = (wt, options = DEFAULTS) => {
+  const keep = reason => ({ verdict: 'keep', reason, deleteBranch: false })
+  const hold = reason => ({ verdict: 'hold', reason, deleteBranch: false })
+
+  if (wt.isMain) {
+    return keep('メインのチェックアウト')
+  }
+  if (wt.isLocked) {
+    return keep('locked')
+  }
+
+  // 未コミットの変更だけは worktree を消すと本当に失われるので、最優先で守る
+  if (wt.dirtyCount > 0 || wt.untrackedCount > 0) {
+    return hold(
+      `未コミット変更 ${wt.dirtyCount} 件 / 未追跡 ${wt.untrackedCount} 件`,
+    )
+  }
+
+  if (wt.pr && wt.pr.state === 'OPEN') {
+    if (wt.pr.ageDays >= options.staleOpenDays) {
+      return {
+        verdict: 'slim',
+        reason: `PR #${wt.pr.number} は OPEN だが ${wt.pr.ageDays} 日停滞`,
+        deleteBranch: false,
+      }
+    }
+    return keep(`PR #${wt.pr.number} は OPEN（${wt.pr.ageDays} 日前に更新）`)
+  }
+
+  if (wt.pr && (wt.pr.state === 'MERGED' || wt.pr.state === 'CLOSED')) {
+    if (wt.pr.ageDays < options.mergedGraceDays) {
+      return keep(
+        `PR #${wt.pr.number} は ${wt.pr.state} だが猶予 ${options.mergedGraceDays} 日以内`,
+      )
+    }
+    // MERGED なら成果は main にあるのでブランチも消せる。
+    // CLOSED（未マージ）は成果がどこにも無いのでブランチは残す。
+    const merged = wt.pr.state === 'MERGED'
+    return {
+      verdict: 'delete',
+      reason: `PR #${wt.pr.number} が ${wt.pr.state} になってから ${wt.pr.ageDays} 日`,
+      deleteBranch: merged && Boolean(wt.branch),
+    }
+  }
+
+  // ここから先は PR が無い worktree
+  if (wt.aheadOfMain === 0) {
+    if (wt.lastActivityDays < options.emptyGraceDays) {
+      return keep('作りたて')
+    }
+    return {
+      verdict: 'delete',
+      reason: 'PR なし・main からの独自コミットなし（空）',
+      deleteBranch: Boolean(wt.branch),
+    }
+  }
+
+  if (wt.hasRemoteBranch) {
+    return hold(`PR なしだが push 済み（独自コミット ${wt.aheadOfMain} 件）`)
+  }
+  return hold(`未 push の独自コミット ${wt.aheadOfMain} 件 — 消すと失われる`)
+}
+
+/**
+ * 判定結果の件数と解放見込みを集計する。
+ * sizeKb は --size を付けたときだけ埋まるので、null は 0 として扱う。
+ */
+export const summarize = rows => {
+  const counts = { keep: 0, hold: 0, slim: 0, delete: 0 }
+  let freedKb = 0
+  for (const row of rows) {
+    counts[row.verdict] += 1
+    if (row.verdict === 'delete') {
+      freedKb += row.sizeKb ?? 0
+    }
+    if (row.verdict === 'slim') {
+      freedKb += (row.sizeKb ?? 0) * NODE_MODULES_RATIO
+    }
+  }
+  return { counts, freedGb: freedKb / 1024 / 1024 }
+}
+
+// ---------------------------------------------------------------------------
+// 以下は git / gh を叩く I/O 層
+// ---------------------------------------------------------------------------
+
+const git = (args, cwd) => {
+  try {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+  } catch {
+    return ''
+  }
+}
+
+const daysSince = (iso, now = Date.now()) => {
+  if (!iso) {
+    return Number.POSITIVE_INFINITY
+  }
+  return Math.floor((now - new Date(iso).getTime()) / 86_400_000)
+}
+
+/**
+ * 「最後に動きがあったのはいつか」を決める。
+ *
+ * 最終コミット日時だけでは足りない。古い main から生やしたばかりの worktree は
+ * ベースのコミットが古いため「放置された」と誤判定され、稼働中のセッションの
+ * worktree を消してしまう。worktree の管理ファイルが触られた時刻も併せて見る。
+ */
+export const resolveLastActivityDays = (
+  { lastCommitIso, prUpdatedAtIso, worktreeTouchedIso },
+  now = Date.now(),
+) =>
+  Math.min(
+    daysSince(lastCommitIso, now),
+    daysSince(prUpdatedAtIso, now),
+    daysSince(worktreeTouchedIso, now),
+  )
+
+/** `git worktree list --porcelain` を構造化する */
+export const parseWorktreeList = output => {
+  const entries = []
+  let current = null
+  for (const line of output.split(/\r?\n/)) {
+    if (line.startsWith('worktree ')) {
+      current = {
+        path: line.slice('worktree '.length),
+        branch: null,
+        isLocked: false,
+      }
+      entries.push(current)
+    } else if (current && line.startsWith('branch ')) {
+      current.branch = line.slice('branch refs/heads/'.length)
+    } else if (current && line.startsWith('locked')) {
+      current.isLocked = true
+    }
+  }
+  return entries
+}
+
+/**
+ * `git symbolic-ref refs/remotes/origin/HEAD` の出力から既定ブランチ名を取り出す。
+ * 取得できなければ null（呼び出し側で main → master の順に候補を試す）。
+ */
+export const parseDefaultBranch = output => {
+  const match = /^refs\/remotes\/origin\/(.+)$/.exec((output || '').trim())
+  return match ? match[1] : null
+}
+
+/** 比較の基準にするリモート追跡ブランチ（origin/main 決め打ちにしない） */
+const resolveBaseRef = repoRoot => {
+  const detected = parseDefaultBranch(
+    git(['symbolic-ref', 'refs/remotes/origin/HEAD'], repoRoot),
+  )
+  const candidates = detected ? [detected, 'main', 'master'] : ['main', 'master']
+  for (const name of candidates) {
+    if (git(['show-ref', '--verify', `refs/remotes/origin/${name}`], repoRoot)) {
+      return `origin/${name}`
+    }
+  }
+  return 'origin/main'
+}
+
+// du は node_modules を丸ごと stat して回るので、worktree 1 個で数秒かかる。
+// サイズは表示にしか使わず判定には関与しないため、既定では測らない。
+const directorySizeKb = path => {
+  try {
+    const out = execFileSync('du', ['-sk', path], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+    return Number.parseInt(out.split(/\s+/)[0], 10) || 0
+  } catch {
+    return 0
+  }
+}
+
+/** ブランチに紐づく PR を GitHub に問い合わせる。無ければ null */
+const fetchPr = branch => {
+  if (!branch) {
+    return null
+  }
+  let raw = ''
+  try {
+    raw = execFileSync(
+      'gh',
+      [
+        'pr',
+        'list',
+        '--head',
+        branch,
+        '--state',
+        'all',
+        '--limit',
+        '1',
+        '--json',
+        'number,state,updatedAt,mergedAt,closedAt',
+      ],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    )
+  } catch {
+    return null
+  }
+  const list = JSON.parse(raw || '[]')
+  if (list.length === 0) {
+    return null
+  }
+  const pr = list[0]
+  const stamp =
+    pr.state === 'OPEN'
+      ? pr.updatedAt
+      : pr.mergedAt || pr.closedAt || pr.updatedAt
+  return {
+    number: pr.number,
+    state: pr.state,
+    ageDays: daysSince(stamp),
+    updatedAt: pr.updatedAt,
+  }
+}
+
+/**
+ * worktree の管理ファイルが最後に触られた時刻を管理ディレクトリから読む。
+ *
+ * gitdir は `git worktree add` で作られ、HEAD はチェックアウトやコミットで更新される。
+ * index は含めない。`git status` が stat 情報を書き戻すため、このツールで様子を
+ * 見るだけで mtime が「今」になり、放置された worktree が現役に化けてしまう。
+ */
+export const readWorktreeTouchedAt = adminDir => {
+  if (!adminDir) {
+    return null
+  }
+  const stamps = ['gitdir', 'HEAD']
+    .map(name => {
+      try {
+        return statSync(join(adminDir, name)).mtimeMs
+      } catch {
+        return null
+      }
+    })
+    .filter(value => value !== null)
+  return stamps.length === 0
+    ? null
+    : new Date(Math.max(...stamps)).toISOString()
+}
+
+const worktreeTouchedAt = worktreePath =>
+  readWorktreeTouchedAt(git(['rev-parse', '--absolute-git-dir'], worktreePath))
+
+/** 全 worktree の状態を集める。measureSize は既定 false（du が遅いため） */
+export const collectWorktrees = (repoRoot, { measureSize = false } = {}) => {
+  const commonDir = git(
+    ['rev-parse', '--path-format=absolute', '--git-common-dir'],
+    repoRoot,
+  )
+  const mainPath = commonDir.replace(/\/\.git$/, '')
+  const baseRef = resolveBaseRef(repoRoot)
+
+  return parseWorktreeList(
+    git(['worktree', 'list', '--porcelain'], repoRoot),
+  ).map(entry => {
+    // git status は index を書き戻すことがあり mtime が今になってしまうため、
+    // 「最後に触られた時刻」は status より先に読む
+    const touchedIso = worktreeTouchedAt(entry.path)
+    const status = git(['status', '--porcelain'], entry.path)
+    const lines = status ? status.split(/\r?\n/) : []
+    const ref = entry.branch || 'HEAD'
+    const pr = fetchPr(entry.branch)
+    const lastActivityDays = resolveLastActivityDays({
+      lastCommitIso: git(['log', '-1', '--format=%cI'], entry.path) || null,
+      prUpdatedAtIso: pr ? pr.updatedAt : null,
+      worktreeTouchedIso: touchedIso,
+    })
+
+    return {
+      path: entry.path,
+      branch: entry.branch,
+      isMain: entry.path === mainPath,
+      isLocked: entry.isLocked,
+      dirtyCount: lines.filter(l => l && !l.startsWith('?? ')).length,
+      untrackedCount: lines.filter(l => l.startsWith('?? ')).length,
+      aheadOfMain:
+        Number.parseInt(
+          git(['rev-list', '--count', `${baseRef}..${ref}`], entry.path),
+          10,
+        ) || 0,
+      hasRemoteBranch:
+        entry.branch !== null &&
+        git(
+          ['show-ref', '--verify', `refs/remotes/origin/${entry.branch}`],
+          repoRoot,
+        ) !== '',
+      lastActivityDays,
+      sizeKb: measureSize ? directorySizeKb(entry.path) : null,
+      pr,
+    }
+  })
+}
+
+/** worktree 配下の node_modules を消す（木そのものは残す） */
+const removeNodeModules = (root, depth = 0) => {
+  if (depth > 4 || !existsSync(root)) {
+    return 0
+  }
+  let removed = 0
+  for (const name of readdirSync(root)) {
+    const path = join(root, name)
+    let isDir = false
+    try {
+      isDir = statSync(path).isDirectory()
+    } catch {
+      continue
+    }
+    if (!isDir) {
+      continue
+    }
+    if (name === 'node_modules') {
+      rmSync(path, { recursive: true, force: true })
+      removed += 1
+    } else if (name !== '.git') {
+      removed += removeNodeModules(path, depth + 1)
+    }
+  }
+  return removed
+}
+
+const applyVerdict = (row, repoRoot) => {
+  if (row.verdict === 'slim') {
+    const n = removeNodeModules(row.path)
+    return `node_modules ${n} 個を削除`
+  }
+  if (row.verdict !== 'delete') {
+    return 'なし'
+  }
+  // --force は使わない。git 自身が「汚れていたら消さない」を守ってくれる
+  try {
+    execFileSync('git', ['worktree', 'remove', row.path], {
+      cwd: repoRoot,
+      stdio: ['ignore', 'ignore', 'pipe'],
+    })
+  } catch (error) {
+    return `worktree 削除に失敗: ${String(error.stderr || error.message).trim()}`
+  }
+  if (row.deleteBranch && row.branch) {
+    try {
+      execFileSync('git', ['branch', '-D', row.branch], {
+        cwd: repoRoot,
+        stdio: ['ignore', 'ignore', 'pipe'],
+      })
+      return `worktree とブランチ ${row.branch} を削除`
+    } catch {
+      return 'worktree を削除（ブランチ削除は失敗）'
+    }
+  }
+  return 'worktree を削除'
+}
+
+const NUMERIC_FLAGS = {
+  '--merged-grace': 'mergedGraceDays',
+  '--stale-open': 'staleOpenDays',
+  '--empty-grace': 'emptyGraceDays',
+}
+
+export const parseArgs = argv => {
+  const options = { ...DEFAULTS, apply: false, json: false, size: false }
+  let skipNext = false
+  argv.forEach((arg, index) => {
+    if (skipNext) {
+      skipNext = false
+      return
+    }
+    if (arg === '--apply') {
+      options.apply = true
+    } else if (arg === '--json') {
+      options.json = true
+    } else if (arg === '--size') {
+      options.size = true
+    } else if (NUMERIC_FLAGS[arg]) {
+      const value = Number.parseInt(argv[index + 1], 10)
+      if (Number.isNaN(value)) {
+        throw new Error(`${arg} には日数を指定してください`)
+      }
+      options[NUMERIC_FLAGS[arg]] = value
+      skipNext = true
+    }
+  })
+  return options
+}
+
+const MARKS = {
+  hold: '⚠ 要確認',
+  keep: '  保持  ',
+  slim: '  軽量化',
+  delete: '→ 削除 ',
+}
+const ORDER = { hold: 0, keep: 1, slim: 2, delete: 3 }
+
+const main = () => {
+  const options = parseArgs(process.argv.slice(2))
+  const repoRoot = git(['rev-parse', '--show-toplevel'], process.cwd())
+  if (!repoRoot) {
+    console.error('git リポジトリの中で実行してください')
+    process.exitCode = 1
+    return
+  }
+
+  const rows = collectWorktrees(repoRoot, { measureSize: options.size })
+    .map(wt => ({ ...wt, ...classifyWorktree(wt, options) }))
+    .sort(
+      (a, b) =>
+        ORDER[a.verdict] - ORDER[b.verdict] || (b.sizeKb ?? 0) - (a.sizeKb ?? 0),
+    )
+
+  if (options.apply) {
+    for (const row of rows) {
+      if (row.verdict === 'delete' || row.verdict === 'slim') {
+        row.result = applyVerdict(row, repoRoot)
+      }
+    }
+    git(['worktree', 'prune'], repoRoot)
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify({ rows, summary: summarize(rows) }, null, 2))
+    return
+  }
+
+  console.log(
+    options.apply
+      ? '=== worktree GC（実行） ==='
+      : '=== worktree GC（dry-run / 何も消しません） ===',
+  )
+  for (const row of rows) {
+    const name = row.path.split('/').pop().slice(0, 34).padEnd(34)
+    const size =
+      row.sizeKb === null
+        ? ''
+        : ` ${(row.sizeKb / 1024 / 1024).toFixed(1).padStart(5)}GB`
+    console.log(`${MARKS[row.verdict]} ${name}${size}  ${row.reason}`)
+    if (row.result) {
+      console.log(`${' '.repeat(9)}└─ ${row.result}`)
+    }
+  }
+
+  const { counts, freedGb } = summarize(rows)
+  console.log(
+    `\n削除 ${counts.delete} / 軽量化 ${counts.slim} / 保持 ${counts.keep} / 要確認 ${counts.hold}`,
+  )
+  if (options.size) {
+    console.log(
+      `${options.apply ? '解放' : '解放見込み'}: 約 ${freedGb.toFixed(1)} GB`,
+    )
+  } else {
+    console.log('サイズ未計測（--size を付けると計測します。数十秒かかります）')
+  }
+  if (!options.apply && counts.delete + counts.slim > 0) {
+    console.log('\n実行するには --apply を付けてください。')
+  }
+}
+
+// テストランナー経由で読み込まれたときは実行しない（NODE_TEST_CONTEXT は node --test が設定する）
+if (
+  !process.env.NODE_TEST_CONTEXT &&
+  process.argv[1]?.endsWith('worktree-gc.mjs')
+) {
+  main()
+}

--- a/.claude/skills/worktree-gc/scripts/worktree-gc.test.mjs
+++ b/.claude/skills/worktree-gc/scripts/worktree-gc.test.mjs
@@ -1,0 +1,352 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, utimesSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, it } from 'node:test'
+
+import {
+  classifyWorktree,
+  DEFAULTS,
+  parseArgs,
+  parseDefaultBranch,
+  parseWorktreeList,
+  readWorktreeTouchedAt,
+  resolveLastActivityDays,
+  summarize,
+} from './worktree-gc.mjs'
+
+/** テスト用の worktree 情報を組み立てるヘルパ（既定は「空の使い捨て worktree」） */
+const wt = (overrides = {}) => ({
+  path: '/repo/.claude/worktrees/agent-x',
+  branch: 'claude/agent-x',
+  isMain: false,
+  isLocked: false,
+  dirtyCount: 0,
+  untrackedCount: 0,
+  aheadOfMain: 0,
+  hasRemoteBranch: false,
+  lastActivityDays: 30,
+  sizeKb: 1024 * 1024,
+  pr: null,
+  ...overrides,
+})
+
+describe('classifyWorktree - 保護', () => {
+  it('メインのチェックアウトは常に keep', () => {
+    const r = classifyWorktree(wt({ isMain: true, dirtyCount: 5 }), DEFAULTS)
+    assert.equal(r.verdict, 'keep')
+    assert.equal(r.deleteBranch, false)
+  })
+
+  it('locked な worktree は keep', () => {
+    const r = classifyWorktree(wt({ isLocked: true }), DEFAULTS)
+    assert.equal(r.verdict, 'keep')
+  })
+})
+
+describe('classifyWorktree - 未コミット変更', () => {
+  it('追跡ファイルに変更があれば hold', () => {
+    const r = classifyWorktree(wt({ dirtyCount: 3 }), DEFAULTS)
+    assert.equal(r.verdict, 'hold')
+    assert.match(r.reason, /未コミット変更/)
+  })
+
+  it('未追跡ファイルだけでも hold', () => {
+    const r = classifyWorktree(wt({ untrackedCount: 1 }), DEFAULTS)
+    assert.equal(r.verdict, 'hold')
+  })
+
+  it('PR がマージ済みでも未コミット変更があれば hold が優先される', () => {
+    const r = classifyWorktree(
+      wt({ dirtyCount: 1, pr: { number: 1, state: 'MERGED', ageDays: 90 } }),
+      DEFAULTS,
+    )
+    assert.equal(r.verdict, 'hold')
+  })
+})
+
+describe('classifyWorktree - OPEN な PR', () => {
+  it('更新が新しい OPEN PR は keep', () => {
+    const r = classifyWorktree(
+      wt({ pr: { number: 8152, state: 'OPEN', ageDays: 2 } }),
+      DEFAULTS,
+    )
+    assert.equal(r.verdict, 'keep')
+    assert.match(r.reason, /#8152/)
+  })
+
+  it('停滞した OPEN PR は slim（node_modules のみ削除）', () => {
+    const r = classifyWorktree(
+      wt({
+        pr: { number: 8152, state: 'OPEN', ageDays: DEFAULTS.staleOpenDays },
+      }),
+      DEFAULTS,
+    )
+    assert.equal(r.verdict, 'slim')
+    assert.equal(r.deleteBranch, false)
+  })
+})
+
+describe('classifyWorktree - 閉じた PR', () => {
+  it('MERGED から猶予を過ぎたら delete + ブランチも削除', () => {
+    const r = classifyWorktree(
+      wt({
+        aheadOfMain: 10,
+        pr: {
+          number: 8156,
+          state: 'MERGED',
+          ageDays: DEFAULTS.mergedGraceDays,
+        },
+      }),
+      DEFAULTS,
+    )
+    assert.equal(r.verdict, 'delete')
+    assert.equal(r.deleteBranch, true)
+  })
+
+  it('MERGED でも猶予内なら keep', () => {
+    const r = classifyWorktree(
+      wt({ pr: { number: 8178, state: 'MERGED', ageDays: 0 } }),
+      DEFAULTS,
+    )
+    assert.equal(r.verdict, 'keep')
+  })
+
+  it('CLOSED（未マージ）は worktree だけ消してブランチは残す', () => {
+    const r = classifyWorktree(
+      wt({
+        aheadOfMain: 4,
+        pr: { number: 7000, state: 'CLOSED', ageDays: 30 },
+      }),
+      DEFAULTS,
+    )
+    assert.equal(r.verdict, 'delete')
+    assert.equal(r.deleteBranch, false)
+  })
+})
+
+describe('classifyWorktree - PR なし', () => {
+  it('独自コミットが 0 なら delete（ブランチも削除して良い）', () => {
+    const r = classifyWorktree(wt({ aheadOfMain: 0 }), DEFAULTS)
+    assert.equal(r.verdict, 'delete')
+    assert.equal(r.deleteBranch, true)
+  })
+
+  it('作りたて（猶予内）は keep', () => {
+    const r = classifyWorktree(
+      wt({ aheadOfMain: 0, lastActivityDays: 0 }),
+      DEFAULTS,
+    )
+    assert.equal(r.verdict, 'keep')
+  })
+
+  it('push 済みの独自コミットがあれば hold', () => {
+    const r = classifyWorktree(
+      wt({ aheadOfMain: 2, hasRemoteBranch: true }),
+      DEFAULTS,
+    )
+    assert.equal(r.verdict, 'hold')
+  })
+
+  it('未 push の独自コミットは hold にして警告を出す', () => {
+    const r = classifyWorktree(
+      wt({ aheadOfMain: 2, hasRemoteBranch: false }),
+      DEFAULTS,
+    )
+    assert.equal(r.verdict, 'hold')
+    assert.match(r.reason, /未 push/)
+  })
+
+  it('detached HEAD ではブランチ削除を要求しない', () => {
+    const r = classifyWorktree(wt({ branch: null, aheadOfMain: 0 }), DEFAULTS)
+    assert.equal(r.verdict, 'delete')
+    assert.equal(r.deleteBranch, false)
+  })
+})
+
+describe('resolveLastActivityDays', () => {
+  const now = Date.parse('2026-08-03T02:00:00Z')
+  const daysAgo = n => new Date(now - n * 86_400_000).toISOString()
+
+  it('与えられた時刻のうち最も新しいものを採る', () => {
+    const days = resolveLastActivityDays(
+      {
+        lastCommitIso: daysAgo(30),
+        prUpdatedAtIso: daysAgo(5),
+        worktreeTouchedIso: daysAgo(12),
+      },
+      now,
+    )
+    assert.equal(days, 5)
+  })
+
+  it('作りたての worktree は、ベースのコミットが古くても新しいと判定する', () => {
+    // 稼働中のセッションが古い main から生やした worktree を消さないための保険
+    const days = resolveLastActivityDays(
+      {
+        lastCommitIso: daysAgo(3),
+        prUpdatedAtIso: null,
+        worktreeTouchedIso: daysAgo(0),
+      },
+      now,
+    )
+    assert.equal(days, 0)
+  })
+
+  it('null は無視する', () => {
+    const days = resolveLastActivityDays(
+      {
+        lastCommitIso: daysAgo(7),
+        prUpdatedAtIso: null,
+        worktreeTouchedIso: null,
+      },
+      now,
+    )
+    assert.equal(days, 7)
+  })
+
+  it('手がかりが何も無ければ無限大（＝古い扱い）', () => {
+    const days = resolveLastActivityDays(
+      { lastCommitIso: null, prUpdatedAtIso: null, worktreeTouchedIso: null },
+      now,
+    )
+    assert.equal(days, Number.POSITIVE_INFINITY)
+  })
+})
+
+describe('readWorktreeTouchedAt', () => {
+  const fixture = files => {
+    const dir = mkdtempSync(join(tmpdir(), 'wt-gc-'))
+    for (const [name, epochMs] of Object.entries(files)) {
+      const path = join(dir, name)
+      writeFileSync(path, '')
+      utimesSync(path, epochMs / 1000, epochMs / 1000)
+    }
+    return dir
+  }
+  const at = iso => Date.parse(iso)
+
+  it('gitdir と HEAD の新しい方を返す', () => {
+    const dir = fixture({
+      gitdir: at('2026-07-05T00:00:00Z'),
+      HEAD: at('2026-07-25T00:00:00Z'),
+    })
+    assert.equal(
+      readWorktreeTouchedAt(dir),
+      new Date(at('2026-07-25T00:00:00Z')).toISOString(),
+    )
+  })
+
+  it('index は見ない（git status が書き戻して mtime が今になるため）', () => {
+    const dir = fixture({
+      gitdir: at('2026-07-05T00:00:00Z'),
+      HEAD: at('2026-07-05T00:00:00Z'),
+      index: at('2026-08-03T00:00:00Z'),
+    })
+    assert.equal(
+      readWorktreeTouchedAt(dir),
+      new Date(at('2026-07-05T00:00:00Z')).toISOString(),
+    )
+  })
+
+  it('読めなければ null', () => {
+    assert.equal(
+      readWorktreeTouchedAt(join(tmpdir(), 'wt-gc-does-not-exist')),
+      null,
+    )
+    assert.equal(readWorktreeTouchedAt(''), null)
+  })
+})
+
+describe('parseArgs', () => {
+  it('既定は dry-run', () => {
+    const o = parseArgs([])
+    assert.equal(o.apply, false)
+    assert.equal(o.json, false)
+    assert.equal(o.mergedGraceDays, DEFAULTS.mergedGraceDays)
+  })
+
+  it('閾値を上書きでき、値をフラグとして誤解しない', () => {
+    const o = parseArgs([
+      '--merged-grace',
+      '7',
+      '--apply',
+      '--stale-open',
+      '30',
+    ])
+    assert.equal(o.mergedGraceDays, 7)
+    assert.equal(o.staleOpenDays, 30)
+    assert.equal(o.apply, true)
+  })
+
+  it('日数が無い閾値フラグは弾く', () => {
+    assert.throws(() => parseArgs(['--merged-grace', '--apply']), /日数/)
+  })
+
+  it('サイズ計測は既定で行わない（du が node_modules を走査して遅いため）', () => {
+    assert.equal(parseArgs([]).size, false)
+    assert.equal(parseArgs(['--size']).size, true)
+  })
+})
+
+describe('parseDefaultBranch', () => {
+  it('origin/HEAD の指す先からブランチ名を取り出す', () => {
+    assert.equal(parseDefaultBranch('refs/remotes/origin/main'), 'main')
+    assert.equal(parseDefaultBranch('refs/remotes/origin/master'), 'master')
+  })
+
+  it('スラッシュを含むブランチ名も落とさない', () => {
+    assert.equal(parseDefaultBranch('refs/remotes/origin/release/v2'), 'release/v2')
+  })
+
+  it('取得できなければ null（呼び出し側で候補を順に試す）', () => {
+    assert.equal(parseDefaultBranch(''), null)
+    assert.equal(parseDefaultBranch('fatal: ref refs/remotes/origin/HEAD is not'), null)
+  })
+})
+
+describe('parseWorktreeList', () => {
+  it('branch / detached / locked を読み分ける', () => {
+    const output = [
+      'worktree /repo',
+      'HEAD abc',
+      'branch refs/heads/main',
+      '',
+      'worktree /repo/.claude/worktrees/a',
+      'HEAD def',
+      'detached',
+      '',
+      'worktree /repo/.claude/worktrees/b',
+      'HEAD ghi',
+      'branch refs/heads/feat/x',
+      'locked',
+      '',
+    ].join('\n')
+    const entries = parseWorktreeList(output)
+    assert.equal(entries.length, 3)
+    assert.equal(entries[0].branch, 'main')
+    assert.equal(entries[1].branch, null)
+    assert.equal(entries[2].branch, 'feat/x')
+    assert.equal(entries[2].isLocked, true)
+    assert.equal(entries[0].isLocked, false)
+  })
+})
+
+describe('summarize', () => {
+  it('判定ごとの件数と解放見込みを集計する', () => {
+    const rows = [
+      { verdict: 'delete', sizeKb: 1024 * 1024 },
+      { verdict: 'delete', sizeKb: 1024 * 1024 },
+      { verdict: 'slim', sizeKb: 1024 * 1024 },
+      { verdict: 'keep', sizeKb: 1024 * 1024 },
+      { verdict: 'hold', sizeKb: 1024 * 1024 },
+    ]
+    const s = summarize(rows)
+    assert.equal(s.counts.delete, 2)
+    assert.equal(s.counts.slim, 1)
+    assert.equal(s.counts.keep, 1)
+    assert.equal(s.counts.hold, 1)
+    // delete は全量、slim は node_modules 相当のみ解放される
+    assert.ok(s.freedGb > 2 && s.freedGb < 3)
+  })
+})


### PR DESCRIPTION
## What

Adds a `worktree-gc` skill that cleans up stale git worktrees left behind by parallel agent runs (cmux-team / herdr-team / cmux-agent).

On the machine this was written for, 23 worktrees had accumulated to ~30GB. A first run removed 17 of them and freed ~25GB.

## Why decide by state, not by owner

The previous rule of thumb — "only delete worktrees you created yourself" — cannot tell whether a worktree is safe to remove. This skill looks at what would actually be lost:

| Priority | Condition | Action |
| --- | --- | --- |
| 1 | main checkout, or `locked` | never touched |
| 2 | uncommitted or untracked changes | never deleted |
| 3 | no PR and unpushed commits | never deleted |
| 4 | PR OPEN, updated within 14 days | kept |
| 5 | PR OPEN, stale 14+ days | drops `node_modules` only |
| 6 | PR MERGED/CLOSED for 3+ days | worktree removed (branch too, if MERGED) |
| 7 | no PR, no commits ahead of base | removed after 1 day |

## Design notes

- **git ancestry cannot answer "was this merged".** With squash or rebase merges the branch commits never become ancestors of the base branch, so an ancestry check keeps merged worktrees forever. The PR state from `gh` is the source of truth.
- **Worktree removal and branch deletion are separate.** Removing a worktree only discards uncommitted changes; committed work survives in the branch ref. Branches are deleted only when the PR is MERGED — a CLOSED PR's work exists nowhere else.
- **`git worktree remove` is never called with `--force`**, so git's own refusal to delete dirty trees acts as the last guard.
- **Stashes are safe** — `refs/stash` lives in the common dir and is shared across worktrees.
- **Disk size is display-only** and is therefore opt-in behind `--size`; `du` walks `node_modules` and dominates the runtime (7s vs 24s here).
- **Base branch is detected from `origin/HEAD`** with a main/master fallback, so a stale `origin/HEAD` (as in this repo) still resolves correctly.

## Traps found while running it

Both are pinned by tests so a future rewrite cannot silently reintroduce them.

1. A worktree grown from an old base commit read as "abandoned" because only the last commit date was considered — this would have deleted a live session's worktree three hours after it was created.
2. The `index` mtime is rewritten by `git status`, so merely inspecting worktrees made month-old ones look freshly touched. Only `gitdir` and `HEAD` are consulted now.

## Test

```
node --test ~/.claude/skills/worktree-gc/scripts/worktree-gc.test.mjs
# 31 pass, 0 fail
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a worktree cleanup tool that identifies worktrees to keep, hold, slim, or delete.
  * Supports dry runs, approved deletion, JSON output, size measurement, configurable grace periods, and optional removal of unused dependencies.
  * Considers locks, uncommitted changes, pull request status, branch activity, and recent filesystem activity before cleanup.
* **Documentation**
  * Added usage guidance, safety requirements, configuration options, and cleanup limitations.
* **Tests**
  * Added comprehensive coverage for cleanup decisions, parsing, activity tracking, and command-line options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->