### PR TITLE
chore: codex が生成する .agents ミラーを ignore する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,8 @@ result-*
 !.codex/AGENTS.md
 # local-only agent (project-specific content, not for the public repo)
 .claude/agents/github-issue-manager.md
+
+# Codex desktop's external-agent import mirrors .claude/ into .agents/.
+# Because ~/.claude is a symlink into this repo, that mirror lands here too.
+# It is generated output, not source — the originals live in .claude/skills/.
+.agents/


### PR DESCRIPTION
## Summary

Codex desktop の external-agent import が `.claude/` を `.agents/` にミラーする。`~/.claude` がこのリポジトリへの symlink のため、そのミラーが**リポジトリのワーキングツリーにも 98 ファイルの未追跡ファイルとして落ちてくる**。

生成物であり、元データは `.claude/skills/` にあるので、二重管理せず ignore する。

## 経緯

タイムスタンプが秒単位で一致していて、Codex 側の生成であることが確認できた:

```
16:54:58  ~/.codex/skills/.system                      ← Codex 更新
16:57:26  ~/.agents/skills/
16:57:26  <repo>/.agents/                              ← 同一秒
16:57:26  ~/.codex/sessions/.../rollout-...-16-57-26-*.jsonl
```

`~/.codex/claude-cowork-import-history.json` に `itemType: "CONFIG"` の取り込み記録あり。Claude Code の tooluse ログには生成の形跡なし。

## 補足

現在は `~/.codex/config.toml` の `[desktop] external-agent-import-sync-enabled = false` で同期が止まっているが、フラグが戻れば再発する。そのための ignore。